### PR TITLE
Adding Subroutines and cycle support to Forge.

### DIFF
--- a/Forge.TreeWalker.UnitTests/Forge.TreeWalker.UnitTests.csproj
+++ b/Forge.TreeWalker.UnitTests/Forge.TreeWalker.UnitTests.csproj
@@ -25,7 +25,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>obj\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -33,7 +33,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>obj\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/Forge.TreeWalker.UnitTests/Forge.TreeWalker.UnitTests.csproj
+++ b/Forge.TreeWalker.UnitTests/Forge.TreeWalker.UnitTests.csproj
@@ -49,6 +49,9 @@
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json.Schema, Version=3.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.Schema.3.0.11\lib\net45\Newtonsoft.Json.Schema.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
@@ -56,6 +59,7 @@
     <Compile Include="test\ExecutorUnitTests.cs" />
     <Compile Include="test\ExternalTestType.cs" />
     <Compile Include="test\ForgeSchemaHelper.cs" />
+    <Compile Include="test\ForgeSchemaValidationTests.cs" />
     <Compile Include="test\TreeWalkerUnitTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Forge.TreeWalker.UnitTests/Forge.TreeWalker.UnitTests.csproj
+++ b/Forge.TreeWalker.UnitTests/Forge.TreeWalker.UnitTests.csproj
@@ -40,6 +40,21 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.CodeAnalysis, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.3.2\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp.Scripting, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Scripting.1.3.2\lib\dotnet\Microsoft.CodeAnalysis.CSharp.Scripting.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.Scripting, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Scripting.Common.1.3.2\lib\dotnet\Microsoft.CodeAnalysis.Scripting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.1.2.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>

--- a/Forge.TreeWalker.UnitTests/packages.config
+++ b/Forge.TreeWalker.UnitTests/packages.config
@@ -3,4 +3,5 @@
   <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net462" />
   <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net462" />
+  <package id="Newtonsoft.Json.Schema" version="3.0.11" targetFramework="net462" />
 </packages>

--- a/Forge.TreeWalker.UnitTests/test/ExecutorUnitTests.cs
+++ b/Forge.TreeWalker.UnitTests/test/ExecutorUnitTests.cs
@@ -16,6 +16,7 @@ namespace Forge.TreeWalker.UnitTests
 
     using Forge.ExternalTypes;
     using Forge.TreeWalker;
+    using Newtonsoft.Json.Linq;
 
     [TestClass]
     public class ExecutorUnitTests
@@ -43,7 +44,7 @@ namespace Forge.TreeWalker.UnitTests
         public void TestExecutor_Success_bool()
         {
             this.UserContext.Foo = "Bar";
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null);
+            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, null);
             string expression = "UserContext.Foo == \"Bar\"";
 
             Assert.IsTrue(ex.Execute<bool>(expression).GetAwaiter().GetResult(), "Expected ExpressionExecutor to successfully evaluate a true expression.");
@@ -54,7 +55,7 @@ namespace Forge.TreeWalker.UnitTests
         {
             // Note that long requires casting where int does not.
             this.UserContext.Foo = (long)1000;
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null);
+            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, null);
             string expression = "UserContext.Foo";
 
             Assert.AreEqual((long)1000, ex.Execute<long>(expression).GetAwaiter().GetResult(), "Expected ExpressionExecutor to successfully evaluate the expression.");
@@ -64,7 +65,7 @@ namespace Forge.TreeWalker.UnitTests
         public void TestExecutor_Success_int()
         {
             this.UserContext.Foo = 1000;
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null);
+            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, null);
             string expression = "UserContext.Foo";
 
             Assert.AreEqual(1000, ex.Execute<int>(expression).GetAwaiter().GetResult(), "Expected ExpressionExecutor to successfully evaluate the expression.");
@@ -74,7 +75,7 @@ namespace Forge.TreeWalker.UnitTests
         public void TestExecutor_Success_ExecuteTwice()
         {
             this.UserContext.Foo = "Bar";
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null);
+            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, null);
             string expression = "UserContext.Foo == \"Bar\" && UserContext.GetTopic(\"TopicName\").ResourceType == \"Node\"";
 
             // Test - confirm Execute can compile and execute the same code twice without crashing.
@@ -86,7 +87,7 @@ namespace Forge.TreeWalker.UnitTests
         public void TestExecutor_Fail_MissingDefinitions()
         {
             this.UserContext.Foo = "Bar";
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null);
+            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, null);
             string expression = "UserContext.Bar == \"Bar\"";
 
             try
@@ -103,7 +104,7 @@ namespace Forge.TreeWalker.UnitTests
         public void TestExecutor_Fail_BadExpression()
         {
             this.UserContext.Foo = "Bar";
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null);
+            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, null);
             string expression = "UserContext.Foo";
 
             Assert.ThrowsException<InvalidCastException>(() => 
@@ -118,7 +119,7 @@ namespace Forge.TreeWalker.UnitTests
             this.UserContext.Foo = ExternalTestType.TestEnum;
             List<Type> dependencies = new List<Type>();
             dependencies.Add(typeof(ExternalTestType));
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, dependencies);
+            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, dependencies, null);
             string expression = "UserContext.Foo.ToString() == ExternalTestType.TestEnum.ToString()";
             Assert.IsTrue(ex.Execute<bool>(expression).GetAwaiter().GetResult(), "Expected ExpressionExecutor to successfully evaluate a true expression.");
         }
@@ -127,7 +128,7 @@ namespace Forge.TreeWalker.UnitTests
         public void TestExecutor_Fail_CompileExpressionWithMissingDependencies()
         {
             this.UserContext.Foo = ExternalTestType.ExampleEnum;
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null);
+            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, null);
             string expression = "UserContext.Foo == ExternalTestType.ExampleEnum";
 
             try
@@ -148,7 +149,7 @@ namespace Forge.TreeWalker.UnitTests
             List<Type> dependencies = new List<Type>();
             dependencies.Add(typeof(ExternalTestType));
 
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, dependencies);
+            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, dependencies, null);
             string expression = "UserContext.Foo == ExternalTestType.TestEnum && UserContext.Bar == DiffNamespaceType.TestOne";
 
             try
@@ -169,7 +170,7 @@ namespace Forge.TreeWalker.UnitTests
             List<Type> dependencies = new List<Type>();
             dependencies.Add(typeof(ExternalTestType));
 
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, dependencies);
+            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, dependencies, null);
             string expression = "UserContext.Foo.ToString() == ExternalTestType.TestEnum.ToString() && UserContext.Bar.ToString() == TestType.Test.ToString()";
             Assert.IsTrue(ex.Execute<bool>(expression).GetAwaiter().GetResult(), "Expected ExpressionExecutor to successfully evaluate a true expression.");
         }
@@ -185,7 +186,7 @@ namespace Forge.TreeWalker.UnitTests
             dependencies.Add(typeof(Type));
 
             // Default dependencies are expected to be tossed away internally in ExpressionExecutor. 
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null);
+            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, null);
             string expression = "UserContext.Foo == \"Foo\"";
             Assert.IsTrue(ex.Execute<bool>(expression).GetAwaiter().GetResult(), "Expected ExpressionExecutor to successfully evaluate a true expression.");
         }
@@ -193,7 +194,7 @@ namespace Forge.TreeWalker.UnitTests
         [TestMethod]
         public void TestExecutor_Success_ChangingFunctionDefinition()
         {
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null);
+            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, null);
 
             // Rewritting GetCount to return 2
             string expression="UserContext.GetCount = new Func<int>(() => 2)";
@@ -205,7 +206,7 @@ namespace Forge.TreeWalker.UnitTests
         [TestMethod]
         public void TestExecutor_Fail_ChangingFunctionReturnType()
         {
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null);
+            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, null);
 
             // Changing return type of GetCount
             string expression = "UserContext.GetCount = new Func<string>(() => \"Test\")";
@@ -219,7 +220,7 @@ namespace Forge.TreeWalker.UnitTests
         [TestMethod]
         public void TestExecutor_Success_ChangingFunctionReturnType()
         {
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null);
+            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, null);
 
             // Changing return type of GetCount
             string expression = "UserContext.GetCount = new Func<string>(() => \"Test\")";
@@ -232,7 +233,7 @@ namespace Forge.TreeWalker.UnitTests
         [TestMethod]
         public void TestExecutor_Fail_ExecutingMultipleStatements()
         {
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null);
+            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, null);
 
             // Changing return type of GetCount
             string expression = "int x = UserContext.GetCount() + 5; UserContext.GetCount = new Func<int>(() => x); return UserContext.GetCount()";
@@ -254,7 +255,7 @@ namespace Forge.TreeWalker.UnitTests
             string expression = "(Func<bool>)(() => {return UserContext.Foo == \"Bar\";})";
 
             // Casting the expression to Func<bool> since the executor will return a delegate of type Func<bool>
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null);
+            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, null);
             dynamic expressionResult = ex.Execute<Delegate>(expression).GetAwaiter().GetResult();
 
             if (expressionResult.GetType() == typeof(Func<bool>))
@@ -277,7 +278,7 @@ namespace Forge.TreeWalker.UnitTests
             string expression = "(Func<Task<bool>>)(() => {return Task.FromResult(UserContext.Foo == \"Bar\");})";
 
             // Casting the expression to Func<bool> since the executor will return a delegate of type Func<bool>
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null);
+            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, null);
             dynamic expressionResult = ex.Execute<Delegate>(expression).GetAwaiter().GetResult();
             
             if (expressionResult.GetType() == typeof(Func<Task<bool>>))
@@ -300,12 +301,45 @@ namespace Forge.TreeWalker.UnitTests
             string expression = "UserContext.Foo == \"Bar\" && UserContext.GetTopic(\"TopicName\").ResourceType == \"Node\"";
 
             // Test - confirm ExpressionExecutor script cache does not contain script before executing.
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null);
+            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, null);
             Assert.IsFalse(ex.ScriptCacheContainsKey(expression));
 
             // Test - confirm ExpressionExecutor script cache does contain script after executing.
             Assert.IsTrue(ex.Execute<bool>(expression).GetAwaiter().GetResult());
             Assert.IsTrue(ex.ScriptCacheContainsKey(expression));
         }
+
+        [TestMethod]
+        public void TestExecutor_TreeInput_Success()
+        {
+            object treeInput = "TestValue";
+            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, treeInput);
+            string expression = "TreeInput == \"TestValue\"";
+
+            Assert.IsTrue(ex.Execute<bool>(expression).GetAwaiter().GetResult(), "Expected ExpressionExecutor to successfully evaluate a true expression using TreeInput.");
+        }
+
+        [TestMethod]
+        public void TestExecutor_TreeInputJObject_Success()
+        {
+            JObject treeInput = new JObject();
+            treeInput["StringProperty"] = "TestValue";
+            treeInput["IntProperty"] = 10;
+
+            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, treeInput);
+            string expression = "TreeInput.StringProperty == \"TestValue\" && TreeInput.IntProperty == 10";
+
+            Assert.IsTrue(ex.Execute<bool>(expression).GetAwaiter().GetResult(), "Expected ExpressionExecutor to successfully evaluate a true expression using TreeInput as JObject.");
+        }
+
+        [TestMethod]
+        public void TestExecutor_TreeInputNull_Success()
+        {
+            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, null);
+            string expression = "TreeInput == null";
+
+            Assert.IsTrue(ex.Execute<bool>(expression).GetAwaiter().GetResult(), "Expected ExpressionExecutor to successfully evaluate a true expression using TreeInput as null.");
+        }
+
     }
 }

--- a/Forge.TreeWalker.UnitTests/test/ExecutorUnitTests.cs
+++ b/Forge.TreeWalker.UnitTests/test/ExecutorUnitTests.cs
@@ -44,7 +44,7 @@ namespace Forge.TreeWalker.UnitTests
         public void TestExecutor_Success_bool()
         {
             this.UserContext.Foo = "Bar";
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, null);
+            ExpressionExecutor ex = new ExpressionExecutor(session: null, userContext: this.UserContext);
             string expression = "UserContext.Foo == \"Bar\"";
 
             Assert.IsTrue(ex.Execute<bool>(expression).GetAwaiter().GetResult(), "Expected ExpressionExecutor to successfully evaluate a true expression.");
@@ -55,7 +55,7 @@ namespace Forge.TreeWalker.UnitTests
         {
             // Note that long requires casting where int does not.
             this.UserContext.Foo = (long)1000;
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, null);
+            ExpressionExecutor ex = new ExpressionExecutor(session: null, userContext: this.UserContext);
             string expression = "UserContext.Foo";
 
             Assert.AreEqual((long)1000, ex.Execute<long>(expression).GetAwaiter().GetResult(), "Expected ExpressionExecutor to successfully evaluate the expression.");
@@ -65,7 +65,7 @@ namespace Forge.TreeWalker.UnitTests
         public void TestExecutor_Success_int()
         {
             this.UserContext.Foo = 1000;
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, null);
+            ExpressionExecutor ex = new ExpressionExecutor(session: null, userContext: this.UserContext);
             string expression = "UserContext.Foo";
 
             Assert.AreEqual(1000, ex.Execute<int>(expression).GetAwaiter().GetResult(), "Expected ExpressionExecutor to successfully evaluate the expression.");
@@ -75,7 +75,7 @@ namespace Forge.TreeWalker.UnitTests
         public void TestExecutor_Success_ExecuteTwice()
         {
             this.UserContext.Foo = "Bar";
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, null);
+            ExpressionExecutor ex = new ExpressionExecutor(session: null, userContext: this.UserContext);
             string expression = "UserContext.Foo == \"Bar\" && UserContext.GetTopic(\"TopicName\").ResourceType == \"Node\"";
 
             // Test - confirm Execute can compile and execute the same code twice without crashing.
@@ -87,7 +87,7 @@ namespace Forge.TreeWalker.UnitTests
         public void TestExecutor_Fail_MissingDefinitions()
         {
             this.UserContext.Foo = "Bar";
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, null);
+            ExpressionExecutor ex = new ExpressionExecutor(session: null, userContext: this.UserContext);
             string expression = "UserContext.Bar == \"Bar\"";
 
             try
@@ -104,7 +104,7 @@ namespace Forge.TreeWalker.UnitTests
         public void TestExecutor_Fail_BadExpression()
         {
             this.UserContext.Foo = "Bar";
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, null);
+            ExpressionExecutor ex = new ExpressionExecutor(session: null, userContext: this.UserContext);
             string expression = "UserContext.Foo";
 
             Assert.ThrowsException<InvalidCastException>(() => 
@@ -119,7 +119,7 @@ namespace Forge.TreeWalker.UnitTests
             this.UserContext.Foo = ExternalTestType.TestEnum;
             List<Type> dependencies = new List<Type>();
             dependencies.Add(typeof(ExternalTestType));
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, dependencies, null);
+            ExpressionExecutor ex = new ExpressionExecutor(session: null, userContext: this.UserContext, dependencies: dependencies);
             string expression = "UserContext.Foo.ToString() == ExternalTestType.TestEnum.ToString()";
             Assert.IsTrue(ex.Execute<bool>(expression).GetAwaiter().GetResult(), "Expected ExpressionExecutor to successfully evaluate a true expression.");
         }
@@ -128,7 +128,7 @@ namespace Forge.TreeWalker.UnitTests
         public void TestExecutor_Fail_CompileExpressionWithMissingDependencies()
         {
             this.UserContext.Foo = ExternalTestType.ExampleEnum;
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, null);
+            ExpressionExecutor ex = new ExpressionExecutor(session: null, userContext: this.UserContext);
             string expression = "UserContext.Foo == ExternalTestType.ExampleEnum";
 
             try
@@ -149,7 +149,7 @@ namespace Forge.TreeWalker.UnitTests
             List<Type> dependencies = new List<Type>();
             dependencies.Add(typeof(ExternalTestType));
 
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, dependencies, null);
+            ExpressionExecutor ex = new ExpressionExecutor(session: null, userContext: this.UserContext, dependencies: dependencies);
             string expression = "UserContext.Foo == ExternalTestType.TestEnum && UserContext.Bar == DiffNamespaceType.TestOne";
 
             try
@@ -170,7 +170,7 @@ namespace Forge.TreeWalker.UnitTests
             List<Type> dependencies = new List<Type>();
             dependencies.Add(typeof(ExternalTestType));
 
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, dependencies, null);
+            ExpressionExecutor ex = new ExpressionExecutor(session: null, userContext: this.UserContext, dependencies: dependencies);
             string expression = "UserContext.Foo.ToString() == ExternalTestType.TestEnum.ToString() && UserContext.Bar.ToString() == TestType.Test.ToString()";
             Assert.IsTrue(ex.Execute<bool>(expression).GetAwaiter().GetResult(), "Expected ExpressionExecutor to successfully evaluate a true expression.");
         }
@@ -186,7 +186,7 @@ namespace Forge.TreeWalker.UnitTests
             dependencies.Add(typeof(Type));
 
             // Default dependencies are expected to be tossed away internally in ExpressionExecutor. 
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, null);
+            ExpressionExecutor ex = new ExpressionExecutor(session: null, userContext: this.UserContext);
             string expression = "UserContext.Foo == \"Foo\"";
             Assert.IsTrue(ex.Execute<bool>(expression).GetAwaiter().GetResult(), "Expected ExpressionExecutor to successfully evaluate a true expression.");
         }
@@ -194,7 +194,7 @@ namespace Forge.TreeWalker.UnitTests
         [TestMethod]
         public void TestExecutor_Success_ChangingFunctionDefinition()
         {
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, null);
+            ExpressionExecutor ex = new ExpressionExecutor(session: null, userContext: this.UserContext);
 
             // Rewritting GetCount to return 2
             string expression="UserContext.GetCount = new Func<int>(() => 2)";
@@ -206,7 +206,7 @@ namespace Forge.TreeWalker.UnitTests
         [TestMethod]
         public void TestExecutor_Fail_ChangingFunctionReturnType()
         {
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, null);
+            ExpressionExecutor ex = new ExpressionExecutor(session: null, userContext: this.UserContext);
 
             // Changing return type of GetCount
             string expression = "UserContext.GetCount = new Func<string>(() => \"Test\")";
@@ -220,7 +220,7 @@ namespace Forge.TreeWalker.UnitTests
         [TestMethod]
         public void TestExecutor_Success_ChangingFunctionReturnType()
         {
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, null);
+            ExpressionExecutor ex = new ExpressionExecutor(session: null, userContext: this.UserContext);
 
             // Changing return type of GetCount
             string expression = "UserContext.GetCount = new Func<string>(() => \"Test\")";
@@ -233,7 +233,7 @@ namespace Forge.TreeWalker.UnitTests
         [TestMethod]
         public void TestExecutor_Fail_ExecutingMultipleStatements()
         {
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, null);
+            ExpressionExecutor ex = new ExpressionExecutor(session: null, userContext: this.UserContext);
 
             // Changing return type of GetCount
             string expression = "int x = UserContext.GetCount() + 5; UserContext.GetCount = new Func<int>(() => x); return UserContext.GetCount()";
@@ -255,7 +255,7 @@ namespace Forge.TreeWalker.UnitTests
             string expression = "(Func<bool>)(() => {return UserContext.Foo == \"Bar\";})";
 
             // Casting the expression to Func<bool> since the executor will return a delegate of type Func<bool>
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, null);
+            ExpressionExecutor ex = new ExpressionExecutor(session: null, userContext: this.UserContext);
             dynamic expressionResult = ex.Execute<Delegate>(expression).GetAwaiter().GetResult();
 
             if (expressionResult.GetType() == typeof(Func<bool>))
@@ -278,7 +278,7 @@ namespace Forge.TreeWalker.UnitTests
             string expression = "(Func<Task<bool>>)(() => {return Task.FromResult(UserContext.Foo == \"Bar\");})";
 
             // Casting the expression to Func<bool> since the executor will return a delegate of type Func<bool>
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, null);
+            ExpressionExecutor ex = new ExpressionExecutor(session: null, userContext: this.UserContext);
             dynamic expressionResult = ex.Execute<Delegate>(expression).GetAwaiter().GetResult();
             
             if (expressionResult.GetType() == typeof(Func<Task<bool>>))
@@ -301,7 +301,7 @@ namespace Forge.TreeWalker.UnitTests
             string expression = "UserContext.Foo == \"Bar\" && UserContext.GetTopic(\"TopicName\").ResourceType == \"Node\"";
 
             // Test - confirm ExpressionExecutor script cache does not contain script before executing.
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, null);
+            ExpressionExecutor ex = new ExpressionExecutor(session: null, userContext: this.UserContext);
             Assert.IsFalse(ex.ScriptCacheContainsKey(expression));
 
             // Test - confirm ExpressionExecutor script cache does contain script after executing.
@@ -313,7 +313,7 @@ namespace Forge.TreeWalker.UnitTests
         public void TestExecutor_TreeInput_Success()
         {
             object treeInput = "TestValue";
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, treeInput);
+            ExpressionExecutor ex = new ExpressionExecutor(session: null, userContext: this.UserContext, dependencies: null, scriptCache: null, treeInput: treeInput);
             string expression = "TreeInput == \"TestValue\"";
 
             Assert.IsTrue(ex.Execute<bool>(expression).GetAwaiter().GetResult(), "Expected ExpressionExecutor to successfully evaluate a true expression using TreeInput.");
@@ -326,7 +326,7 @@ namespace Forge.TreeWalker.UnitTests
             treeInput["StringProperty"] = "TestValue";
             treeInput["IntProperty"] = 10;
 
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, treeInput);
+            ExpressionExecutor ex = new ExpressionExecutor(session: null, userContext: this.UserContext, dependencies: null, scriptCache: null, treeInput: treeInput);
             string expression = "TreeInput.StringProperty == \"TestValue\" && TreeInput.IntProperty == 10";
 
             Assert.IsTrue(ex.Execute<bool>(expression).GetAwaiter().GetResult(), "Expected ExpressionExecutor to successfully evaluate a true expression using TreeInput as JObject.");
@@ -335,7 +335,7 @@ namespace Forge.TreeWalker.UnitTests
         [TestMethod]
         public void TestExecutor_TreeInputNull_Success()
         {
-            ExpressionExecutor ex = new ExpressionExecutor(null, this.UserContext, null, null);
+            ExpressionExecutor ex = new ExpressionExecutor(session: null, userContext: this.UserContext);
             string expression = "TreeInput == null";
 
             Assert.IsTrue(ex.Execute<bool>(expression).GetAwaiter().GetResult(), "Expected ExpressionExecutor to successfully evaluate a true expression using TreeInput as null.");

--- a/Forge.TreeWalker.UnitTests/test/ForgeSchemaHelper.cs
+++ b/Forge.TreeWalker.UnitTests/test/ForgeSchemaHelper.cs
@@ -16,8 +16,7 @@ namespace Forge.TreeWalker.UnitTests
                 ""Tree"": {
                     ""Root"": {
                         ""Type"": ""Selection"",
-                        ""ChildSelector"":
-                        [
+                        ""ChildSelector"": [
                             {
                                 ""Label"": ""Node"",
                                 ""ShouldSelect"": ""C#|UserContext.ResourceType == \""Node\"""",
@@ -32,8 +31,7 @@ namespace Forge.TreeWalker.UnitTests
                     },
                     ""Container"": {
                         ""Type"": ""Action"",
-                        ""Actions"":
-                        {
+                        ""Actions"": {
                             ""Container_CollectDiagnosticsAction"": {
                                 ""Action"": ""CollectDiagnosticsAction"",
                                 ""Input"":
@@ -42,8 +40,7 @@ namespace Forge.TreeWalker.UnitTests
                                 }
                             }
                         },
-                        ""ChildSelector"":
-                        [
+                        ""ChildSelector"": [
                             {
                                 ""Label"": ""Label"",
                                 ""ShouldSelect"": ""C#|Session.GetLastActionResponse().Status == \""Success\"""",
@@ -53,14 +50,12 @@ namespace Forge.TreeWalker.UnitTests
                     },
                     ""Tardigrade"": {
                         ""Type"": ""Action"",
-                        ""Actions"":
-                        {
+                        ""Actions"": {
                             ""Tardigrade_TardigradeAction"": {
                                 ""Action"": ""TardigradeAction""
                             }
                         },
-                        ""ChildSelector"":
-                        [
+                        ""ChildSelector"": [
                             {
                                 ""Label"": ""Label"",
                                 ""ShouldSelect"": ""C#|Session.GetLastActionResponse().Status == \""Success\"""",
@@ -76,16 +71,13 @@ namespace Forge.TreeWalker.UnitTests
 
         public const string ActionException_Fail = @"
             {
-                ""Tree"":
-                {
+                ""Tree"": {
                     ""Root"": {
                         ""Type"": ""Action"",
-                        ""Actions"":
-                        {
+                        ""Actions"": {
                             ""Root_TestDelayExceptionAction"": {
                                 ""Action"": ""TestDelayExceptionAction"",
-                                ""Input"":
-                                {
+                                ""Input"": {
                                     ""ThrowException"": true
                                 }
                             }
@@ -96,16 +88,13 @@ namespace Forge.TreeWalker.UnitTests
 
         public const string ActionException_ContinuationOnRetryExhaustion = @"
             {
-                ""Tree"":
-                {
+                ""Tree"": {
                     ""Root"": {
                         ""Type"": ""Action"",
-                        ""Actions"":
-                        {
+                        ""Actions"": {
                             ""Root_TestDelayExceptionAction"": {
                                 ""Action"": ""TestDelayExceptionAction"",
-                                ""Input"":
-                                {
+                                ""Input"": {
                                     ""ThrowException"": true
                                 },
                                 ""ContinuationOnRetryExhaustion"": true
@@ -117,16 +106,13 @@ namespace Forge.TreeWalker.UnitTests
 
         public const string ActionDelay_Fail = @"
             {
-                ""Tree"":
-                {
+                ""Tree"": {
                     ""Root"": {
                         ""Type"": ""Action"",
-                        ""Actions"":
-                        {
+                        ""Actions"": {
                             ""Root_TestDelayExceptionAction"": {
                                 ""Action"": ""TestDelayExceptionAction"",
-                                ""Input"":
-                                {
+                                ""Input"": {
                                     ""DelayMilliseconds"": 50
                                 },
                                 ""Timeout"": 10,
@@ -138,16 +124,13 @@ namespace Forge.TreeWalker.UnitTests
 
         public const string ActionDelay_ContinuationOnTimeout = @"
             {
-                ""Tree"":
-                {
+                ""Tree"": {
                     ""Root"": {
                         ""Type"": ""Action"",
-                        ""Actions"":
-                        {
+                        ""Actions"": {
                             ""Root_TestDelayExceptionAction"": {
                                 ""Action"": ""TestDelayExceptionAction"",
-                                ""Input"":
-                                {
+                                ""Input"": {
                                     ""DelayMilliseconds"": 50
                                 },
                                 ""Timeout"": 10,
@@ -160,22 +143,18 @@ namespace Forge.TreeWalker.UnitTests
 
         public const string ActionDelay_ContinuationOnTimeout_RetryPolicy_TimeoutInAction = @"
             {
-                ""Tree"":
-                {
+                ""Tree"": {
                     ""Root"": {
                         ""Type"": ""Action"",
-                        ""Actions"":
-                        {
+                        ""Actions"": {
                             ""Root_TestDelayExceptionAction"": {
                                 ""Action"": ""TestDelayExceptionAction"",
-                                ""Input"":
-                                {
+                                ""Input"": {
                                     ""DelayMilliseconds"": 50,
                                     ""ThrowException"": true
                                 },
                                 ""Timeout"": 100,
-                                ""RetryPolicy"":
-                                {
+                                ""RetryPolicy"": {
                                     ""Type"": ""FixedInterval"",
                                     ""MinBackoffMs"": 25
                                 },
@@ -188,22 +167,18 @@ namespace Forge.TreeWalker.UnitTests
 
         public const string ActionDelay_ContinuationOnTimeout_RetryPolicy_TimeoutBetweenRetries = @"
             {
-                ""Tree"":
-                {
+                ""Tree"": {
                     ""Root"": {
                         ""Type"": ""Action"",
-                        ""Actions"":
-                        {
+                        ""Actions"": {
                             ""Root_TestDelayExceptionAction"": {
                                 ""Action"": ""TestDelayExceptionAction"",
-                                ""Input"":
-                                {
+                                ""Input"": {
                                     ""DelayMilliseconds"": 25,
                                     ""ThrowException"": true
                                 },
                                 ""Timeout"": 50,
-                                ""RetryPolicy"":
-                                {
+                                ""RetryPolicy"": {
                                     ""Type"": ""FixedInterval"",
                                     ""MinBackoffMs"": 100
                                 },
@@ -216,12 +191,10 @@ namespace Forge.TreeWalker.UnitTests
 
         public const string NoChildMatch = @"
             {
-                ""Tree"":
-                {
+                ""Tree"": {
                     ""Root"": {
                         ""Type"": ""Selection"",
-                        ""ChildSelector"":
-                        [
+                        ""ChildSelector"": [
                             {
                                 ""Label"": ""Label"",
                                 ""ShouldSelect"": ""C#|false"",
@@ -238,27 +211,22 @@ namespace Forge.TreeWalker.UnitTests
 
         public const string TestEvaluateInputTypeAction = @"
             {
-                ""Tree"":
-                {
+                ""Tree"": {
                     ""Root"": {
                         ""Type"": ""Action"",
-                        ""Actions"":
-                        {
+                        ""Actions"": {
                             ""Root_TestEvaluateInputTypeAction"": {
                                 ""Action"": ""TestEvaluateInputTypeAction"",
-                                ""Input"":
-                                {
+                                ""Input"": {
                                     ""Command"": ""tasklist"",
                                     ""IntExpression"": ""C#<Int64>|UserContext.GetCount()"",
                                     ""BoolExpression"": ""C#|true"",
-                                    ""NestedObject"":
-                                    {
+                                    ""NestedObject"": {
                                         ""Name"": ""C#|string.Format(\""{0}_{1}\"", \""MyName\"", UserContext.Name)"",
                                         ""Value"": ""MyValue"",
                                         ""IntPropertyInObject"": ""C#<Int64>|UserContext.GetCount()""
                                     },
-                                    ""ObjectArray"":
-                                    [
+                                    ""ObjectArray"": [
                                         {
                                             ""Name"": ""C#|UserContext.Name"",
                                             ""Value"": ""FirstValue""
@@ -268,8 +236,15 @@ namespace Forge.TreeWalker.UnitTests
                                             ""Value"": ""SecondValue""
                                         }
                                     ],
-                                    ""StringArray"": [""C#|UserContext.Name"", ""value2""],
-                                    ""LongArray"": [""C#<Int64>|(long)UserContext.GetCount()"", 3, 2],
+                                    ""StringArray"": [
+                                        ""C#|UserContext.Name"",
+                                        ""value2""
+                                    ],
+                                    ""LongArray"": [
+                                        ""C#<Int64>|(long)UserContext.GetCount()"",
+                                        3,
+                                        2
+                                    ],
                                     ""BoolDelegate"": ""C#|(Func<bool>)(() => {return UserContext.GetCount() == 1;})"",
                                     ""BoolDelegateAsync"": ""C#|(Func<Task<bool>>)(async() => { return await UserContext.GetCountAsync() == 2; })"",
                                     ""StringDictionary"": {
@@ -294,16 +269,13 @@ namespace Forge.TreeWalker.UnitTests
 
         public const string TestEvaluateInputType_FailOnField_Action = @"
             {
-                ""Tree"":
-                {
+                ""Tree"": {
                     ""Root"": {
                         ""Type"": ""Action"",
-                        ""Actions"":
-                        {
+                        ""Actions"": {
                             ""Root_TestEvaluateInputType_FailOnField_Action"": {
                                 ""Action"": ""TestEvaluateInputType_FailOnField_Action"",
-                                ""Input"":
-                                {
+                                ""Input"": {
                                     ""UnexpectedField"": true
                                 },
                                 ""ContinuationOnRetryExhaustion"": true
@@ -316,16 +288,13 @@ namespace Forge.TreeWalker.UnitTests
 
         public const string TestEvaluateInputTypeAction_UnexpectedPropertyFail = @"
             {
-                ""Tree"":
-                {
+                ""Tree"": {
                     ""Root"": {
                         ""Type"": ""Action"",
-                        ""Actions"":
-                        {
+                        ""Actions"": {
                             ""Root_TestEvaluateInputTypeAction"": {
                                 ""Action"": ""TestEvaluateInputTypeAction"",
-                                ""Input"":
-                                {
+                                ""Input"": {
                                     ""UnexpectedProperty"": true
                                 },
                                 ""ContinuationOnRetryExhaustion"": true
@@ -338,16 +307,13 @@ namespace Forge.TreeWalker.UnitTests
 
         public const string TestEvaluateInputType_FailOnNonEmptyCtor_Action = @"
             {
-                ""Tree"":
-                {
+                ""Tree"": {
                     ""Root"": {
                         ""Type"": ""Action"",
-                        ""Actions"":
-                        {
+                        ""Actions"": {
                             ""Root_TestEvaluateInputType_FailOnNonEmptyCtor_Action"": {
                                 ""Action"": ""TestEvaluateInputType_FailOnNonEmptyCtor_Action"",
-                                ""Input"":
-                                {
+                                ""Input"": {
                                     ""BoolProperty"": true
                                 },
                                 ""ContinuationOnRetryExhaustion"": true
@@ -360,16 +326,13 @@ namespace Forge.TreeWalker.UnitTests
 
         public const string LeafNodeSummaryAction = @"
             {
-                ""Tree"":
-                {
+                ""Tree"": {
                     ""Root"": {
                         ""Type"": ""Leaf"",
-                        ""Actions"":
-                        {
+                        ""Actions"": {
                             ""Root_LeafNodeSummaryAction"": {
                                 ""Action"": ""LeafNodeSummaryAction"",
-                                ""Input"":
-                                {
+                                ""Input"": {
                                     ""Status"": ""Success"",
                                     ""StatusCode"": 1,
                                     ""Output"": ""TheResult""
@@ -383,22 +346,18 @@ namespace Forge.TreeWalker.UnitTests
 
         public const string LeafNodeSummaryAction_InputIsActionResponse = @"
             {
-                ""Tree"":
-                {
+                ""Tree"": {
                     ""Root"": {
                         ""Type"": ""Action"",
-                        ""Actions"":
-                        {
+                        ""Actions"": {
                             ""Root_CollectDiagnosticsAction"": {
                                 ""Action"": ""CollectDiagnosticsAction"",
-                                ""Input"":
-                                {
+                                ""Input"": {
                                     ""Command"": ""TheCommand""
                                 }
                             }
                         },
-                        ""ChildSelector"":
-                        [
+                        ""ChildSelector"": [
                             {
                                 ""Label"": ""Label"",
                                 ""Child"": ""LeafNodeSummaryTest""
@@ -407,8 +366,7 @@ namespace Forge.TreeWalker.UnitTests
                     },
                     ""LeafNodeSummaryTest"": {
                         ""Type"": ""Leaf"",
-                        ""Actions"":
-                        {
+                        ""Actions"": {
                             ""LeafNodeSummaryTest_LeafNodeSummaryAction"": {
                                 ""Action"": ""LeafNodeSummaryAction"",
                                 ""Input"": ""C#|Session.GetLastActionResponse()""
@@ -421,16 +379,13 @@ namespace Forge.TreeWalker.UnitTests
 
         public const string ExternalExecutors = @"
             {
-                ""Tree"":
-                {
+                ""Tree"": {
                     ""Root"": {
                         ""Type"": ""Leaf"",
-                        ""Actions"":
-                        {
+                        ""Actions"": {
                             ""Root_LeafNodeSummaryAction"": {
                                 ""Action"": ""LeafNodeSummaryAction"",
-                                ""Input"":
-                                {
+                                ""Input"": {
                                     ""Status"": ""External|StatusResult""
                                 }
                             }
@@ -449,8 +404,7 @@ namespace Forge.TreeWalker.UnitTests
                             ""Actions"": {
                                 ""Root_Subroutine"": {
                                     ""Action"": ""SubroutineAction"",
-                                    ""Input"":
-                                    {
+                                    ""Input"": {
                                         ""TreeName"": ""SubroutineTree"",
                                         ""TreeInput"": {
                                             ""TestStatusCode"": 10
@@ -469,8 +423,7 @@ namespace Forge.TreeWalker.UnitTests
                             ""Actions"": {
                                 ""Root_LeafNodeSummaryAction"": {
                                     ""Action"": ""LeafNodeSummaryAction"",
-                                    ""Input"":
-                                    {
+                                    ""Input"": {
                                         ""Status"": ""Success"",
                                         ""StatusCode"": ""C#|(int)TreeInput.TestStatusCode""
                                     }
@@ -491,8 +444,7 @@ namespace Forge.TreeWalker.UnitTests
                             ""Actions"": {
                                 ""Root_Subroutine"": {
                                     ""Action"": ""SubroutineAction"",
-                                    ""Input"":
-                                    {
+                                    ""Input"": {
                                         ""TreeName"": ""SubroutineTree"",
                                         ""TreeInput"": ""TestValue""
                                     }
@@ -520,24 +472,21 @@ namespace Forge.TreeWalker.UnitTests
                             ""Actions"": {
                                 ""Root_Subroutine_One"": {
                                     ""Action"": ""SubroutineAction"",
-                                    ""Input"":
-                                    {
+                                    ""Input"": {
                                         ""TreeName"": ""SubroutineTree"",
                                         ""TreeInput"": ""TestValueOne""
                                     }
                                 },
                                 ""Root_Subroutine_Two"": {
                                     ""Action"": ""SubroutineAction"",
-                                    ""Input"":
-                                    {
+                                    ""Input"": {
                                         ""TreeName"": ""SubroutineTree"",
                                         ""TreeInput"": ""TestValueTwo""
                                     }
                                 },
                                 ""Root_CollectDiagnosticsAction"": {
                                     ""Action"": ""CollectDiagnosticsAction"",
-                                    ""Input"":
-                                    {
+                                    ""Input"": {
                                         ""Command"": ""TheCommand""
                                     }
                                 }
@@ -552,8 +501,7 @@ namespace Forge.TreeWalker.UnitTests
                             ""Actions"": {
                                 ""Root_LeafNodeSummaryAction"": {
                                     ""Action"": ""LeafNodeSummaryAction"",
-                                    ""Input"":
-                                    {
+                                    ""Input"": {
                                         ""Status"": ""C#|(string)TreeInput"",
                                     }
                                 }
@@ -573,8 +521,7 @@ namespace Forge.TreeWalker.UnitTests
                             ""Actions"": {
                                 ""Root_Subroutine"": {
                                     ""Action"": ""SubroutineAction"",
-                                    ""Input"":
-                                    {
+                                    ""Input"": {
                                         ""TreeName"": ""SubroutineTree"",
                                         ""TreeInput"": ""TestValue""
                                     }
@@ -615,8 +562,7 @@ namespace Forge.TreeWalker.UnitTests
                                 ""Action"": ""RevisitAction""
                             }
                         },
-                        ""ChildSelector"":
-                        [
+                        ""ChildSelector"": [
                             {
                                 ""Label"": ""Label"",
                                 ""ShouldSelect"": ""C#|(int)Session.GetLastActionResponse().Output < 3"",
@@ -637,8 +583,7 @@ namespace Forge.TreeWalker.UnitTests
                             ""Actions"": {
                                 ""Root_Subroutine"": {
                                     ""Action"": ""SubroutineAction"",
-                                    ""Input"":
-                                    {
+                                    ""Input"": {
                                         ""TreeName"": ""SubroutineTree""
                                     }
                                 },
@@ -646,8 +591,7 @@ namespace Forge.TreeWalker.UnitTests
                                     ""Action"": ""RevisitAction""
                                 }
                             },
-                            ""ChildSelector"":
-                            [
+                            ""ChildSelector"": [
                                 {
                                     ""Label"": ""Label"",
                                     ""ShouldSelect"": ""C#|(int)Session.GetOutput(\""Root_RevisitAction\"").Output < 3"",

--- a/Forge.TreeWalker.UnitTests/test/ForgeSchemaHelper.cs
+++ b/Forge.TreeWalker.UnitTests/test/ForgeSchemaHelper.cs
@@ -13,17 +13,18 @@ namespace Forge.TreeWalker.UnitTests
     {
         public const string TardigradeScenario = @"
             {
-                ""Tree"":
-                {
+                ""Tree"": {
                     ""Root"": {
                         ""Type"": ""Selection"",
                         ""ChildSelector"":
                         [
                             {
+                                ""Label"": ""Node"",
                                 ""ShouldSelect"": ""C#|UserContext.ResourceType == \""Node\"""",
                                 ""Child"": ""Node""
                             },
                             {
+                                ""Label"": ""Label"",
                                 ""ShouldSelect"": ""C#|UserContext.ResourceType == \""Container\"""",
                                 ""Child"": ""Container""
                             }
@@ -44,6 +45,7 @@ namespace Forge.TreeWalker.UnitTests
                         ""ChildSelector"":
                         [
                             {
+                                ""Label"": ""Label"",
                                 ""ShouldSelect"": ""C#|Session.GetLastActionResponse().Status == \""Success\"""",
                                 ""Child"": ""Tardigrade""
                             }
@@ -60,6 +62,7 @@ namespace Forge.TreeWalker.UnitTests
                         ""ChildSelector"":
                         [
                             {
+                                ""Label"": ""Label"",
                                 ""ShouldSelect"": ""C#|Session.GetLastActionResponse().Status == \""Success\"""",
                                 ""Child"": ""Tardigrade_Success""
                             }
@@ -220,6 +223,7 @@ namespace Forge.TreeWalker.UnitTests
                         ""ChildSelector"":
                         [
                             {
+                                ""Label"": ""Label"",
                                 ""ShouldSelect"": ""C#|false"",
                                 ""Child"": ""LeafNode""
                             }
@@ -250,7 +254,8 @@ namespace Forge.TreeWalker.UnitTests
                                     ""NestedObject"":
                                     {
                                         ""Name"": ""C#|string.Format(\""{0}_{1}\"", \""MyName\"", UserContext.Name)"",
-                                        ""Value"": ""MyValue""
+                                        ""Value"": ""MyValue"",
+                                        ""IntPropertyInObject"": ""C#<Int64>|UserContext.GetCount()""
                                     },
                                     ""ObjectArray"":
                                     [
@@ -263,10 +268,22 @@ namespace Forge.TreeWalker.UnitTests
                                             ""Value"": ""SecondValue""
                                         }
                                     ],
-                                    ""StringArray"": [""value1"", ""value2""],
-                                    ""LongArray"": [1, 3, 2],
+                                    ""StringArray"": [""C#|UserContext.Name"", ""value2""],
+                                    ""LongArray"": [""C#<Int64>|(long)UserContext.GetCount()"", 3, 2],
                                     ""BoolDelegate"": ""C#|(Func<bool>)(() => {return UserContext.GetCount() == 1;})"",
-                                    ""BoolDelegateAsync"": ""C#|(Func<Task<bool>>)(async() => { return await UserContext.GetCountAsync() == 2; })""
+                                    ""BoolDelegateAsync"": ""C#|(Func<Task<bool>>)(async() => { return await UserContext.GetCountAsync() == 2; })"",
+                                    ""StringDictionary"": {
+                                        ""TestKey1"": ""C#|UserContext.Name"",
+                                        ""TestKey2"": ""TestValue2""
+                                    },
+                                    ""DynamicObject"": {
+                                        ""DynamicPropertyString"": ""TestValue1"",
+                                        ""DynamicPropertyInt"": 10,
+                                        ""DynamicPropertyExpression"": ""C#|UserContext.Name"",
+                                        ""DynamicPropertyNestedObject"": {
+                                            ""NestedPropertyOne"": ""NestedValue1""
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -383,6 +400,7 @@ namespace Forge.TreeWalker.UnitTests
                         ""ChildSelector"":
                         [
                             {
+                                ""Label"": ""Label"",
                                 ""Child"": ""LeafNodeSummaryTest""
                             }
                         ]
@@ -414,6 +432,238 @@ namespace Forge.TreeWalker.UnitTests
                                 ""Input"":
                                 {
                                     ""Status"": ""External|StatusResult""
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ";
+
+        public const string SubroutineAction_GetLastActionResponse = @"
+            {
+                ""ParentTree"": {
+                    ""Tree"": {
+                        ""Root"": {
+                            ""Type"": ""Subroutine"",
+                            ""Actions"": {
+                                ""Root_Subroutine"": {
+                                    ""Action"": ""SubroutineAction"",
+                                    ""Input"":
+                                    {
+                                        ""TreeName"": ""SubroutineTree"",
+                                        ""TreeInput"": {
+                                            ""TestStatusCode"": 10
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                ""SubroutineTree"": {
+                    ""RootTreeNodeKey"": ""StartingNode"",
+                    ""Tree"": {
+                        ""StartingNode"": {
+                            ""Type"": ""Leaf"",
+                            ""Actions"": {
+                                ""Root_LeafNodeSummaryAction"": {
+                                    ""Action"": ""LeafNodeSummaryAction"",
+                                    ""Input"":
+                                    {
+                                        ""Status"": ""Success"",
+                                        ""StatusCode"": ""C#|(int)TreeInput.TestStatusCode""
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ";
+
+        public const string SubroutineAction_NoActions = @"
+            {
+                ""RootTree"": {
+                    ""Tree"": {
+                        ""Root"": {
+                            ""Type"": ""Subroutine"",
+                            ""Actions"": {
+                                ""Root_Subroutine"": {
+                                    ""Action"": ""SubroutineAction"",
+                                    ""Input"":
+                                    {
+                                        ""TreeName"": ""SubroutineTree"",
+                                        ""TreeInput"": ""TestValue""
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                ""SubroutineTree"": {
+                    ""Tree"": {
+                        ""Root"": {
+                            ""Type"": ""Leaf""
+                        }
+                    }
+                }
+            }
+        ";
+
+        public const string SubroutineAction_ParallelSubroutineActions = @"
+            {
+                ""RootTree"": {
+                    ""Tree"": {
+                        ""Root"": {
+                            ""Type"": ""Subroutine"",
+                            ""Actions"": {
+                                ""Root_Subroutine_One"": {
+                                    ""Action"": ""SubroutineAction"",
+                                    ""Input"":
+                                    {
+                                        ""TreeName"": ""SubroutineTree"",
+                                        ""TreeInput"": ""TestValueOne""
+                                    }
+                                },
+                                ""Root_Subroutine_Two"": {
+                                    ""Action"": ""SubroutineAction"",
+                                    ""Input"":
+                                    {
+                                        ""TreeName"": ""SubroutineTree"",
+                                        ""TreeInput"": ""TestValueTwo""
+                                    }
+                                },
+                                ""Root_CollectDiagnosticsAction"": {
+                                    ""Action"": ""CollectDiagnosticsAction"",
+                                    ""Input"":
+                                    {
+                                        ""Command"": ""TheCommand""
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                ""SubroutineTree"": {
+                    ""Tree"": {
+                        ""Root"": {
+                            ""Type"": ""Leaf"",
+                            ""Actions"": {
+                                ""Root_LeafNodeSummaryAction"": {
+                                    ""Action"": ""LeafNodeSummaryAction"",
+                                    ""Input"":
+                                    {
+                                        ""Status"": ""C#|(string)TreeInput"",
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        ";
+
+        public const string SubroutineAction_FailsOnActionTreeNodeType = @"
+            {
+                ""RootTree"": {
+                    ""Tree"": {
+                        ""Root"": {
+                            ""Type"": ""Action"",
+                            ""Actions"": {
+                                ""Root_Subroutine"": {
+                                    ""Action"": ""SubroutineAction"",
+                                    ""Input"":
+                                    {
+                                        ""TreeName"": ""SubroutineTree"",
+                                        ""TreeInput"": ""TestValue""
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                ""SubroutineTree"": {
+                    ""Tree"": {
+                        ""Root"": {
+                            ""Type"": ""Leaf""
+                        }
+                    }
+                }
+            }
+        ";
+
+        public const string SubroutineAction_FailsOnNoSubroutineAction = @"
+            {
+                ""RootTree"": {
+                    ""Tree"": {
+                        ""Root"": {
+                            ""Type"": ""Subroutine""
+                        }
+                    }
+                }
+            }
+        ";
+
+        public const string CycleSchema = @"
+            {
+                ""Tree"": {
+                    ""Root"": {
+                        ""Type"": ""Action"",
+                        ""Actions"": {
+                            ""Root_RevisitAction"": {
+                                ""Action"": ""RevisitAction""
+                            }
+                        },
+                        ""ChildSelector"":
+                        [
+                            {
+                                ""Label"": ""Label"",
+                                ""ShouldSelect"": ""C#|(int)Session.GetLastActionResponse().Output < 3"",
+                                ""Child"": ""Root""
+                            }
+                        ]
+                    }
+                }
+            }
+        ";
+
+        public const string Cycle_SubroutineActionUsesDifferentSessionId = @"
+            {
+                ""RootTree"": {
+                    ""Tree"": {
+                        ""Root"": {
+                            ""Type"": ""Subroutine"",
+                            ""Actions"": {
+                                ""Root_Subroutine"": {
+                                    ""Action"": ""SubroutineAction"",
+                                    ""Input"":
+                                    {
+                                        ""TreeName"": ""SubroutineTree""
+                                    }
+                                },
+                                ""Root_RevisitAction"": {
+                                    ""Action"": ""RevisitAction""
+                                }
+                            },
+                            ""ChildSelector"":
+                            [
+                                {
+                                    ""Label"": ""Label"",
+                                    ""ShouldSelect"": ""C#|(int)Session.GetOutput(\""Root_RevisitAction\"").Output < 3"",
+                                    ""Child"": ""Root""
+                                }
+                            ]
+                        }
+                    }
+                },
+                ""SubroutineTree"": {
+                    ""Tree"": {
+                        ""Root"": {
+                            ""Type"": ""Action"",
+                                ""Actions"": {
+                                ""Root_ReturnSessionIdAction"": {
+                                    ""Action"": ""ReturnSessionIdAction""
                                 }
                             }
                         }

--- a/Forge.TreeWalker.UnitTests/test/ForgeSchemaValidationTests.cs
+++ b/Forge.TreeWalker.UnitTests/test/ForgeSchemaValidationTests.cs
@@ -1,0 +1,184 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ForgeSchemaValidationTests.cs" company="Microsoft">
+//     Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+// <summary>
+//     Tests the ForgeSchemaValidationRules.json file against schemas in ForgeSchemaHelper class.
+// </summary>
+//-----------------------------------------------------------------------
+
+namespace Forge.TreeWalker.UnitTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Reflection;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    using Forge.DataContracts;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+    using Newtonsoft.Json.Schema;
+
+    [TestClass]
+    public class ForgeSchemaValidationTests
+    {
+        private string jsonSchemaRules;
+        private JSchema rules;
+        private Dictionary<string, List<string>> jsonSchemaFailureBlacklist;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            // Load the json schema validation rules.
+            this.jsonSchemaRules = File.ReadAllText(Path.Combine(Environment.CurrentDirectory, "contracts\\ForgeSchemaValidationRules.json"));
+            this.rules = JSchema.Parse(this.jsonSchemaRules);
+
+            // Update the blacklist of forgeTrees that are expected to fail validation for testing purposes.
+            // Key is the const string variable name representing a schema file in ForgeSchemaHelper.
+            // Value is the list of TreeNames in the schema if the schema has TreeNames. Or "NA" if the schema contains just a ForgeTree without TreeName.
+            this.jsonSchemaFailureBlacklist = new Dictionary<string, List<string>>()
+            {
+                {
+                    "SubroutineAction_FailsOnActionTreeNodeType",
+                    new List<string>
+                    {
+                        "RootTree"
+                    }
+                },
+                {
+                    "SubroutineAction_FailsOnNoSubroutineAction",
+                    new List<string>
+                    {
+                        "RootTree"
+                    }
+                }
+            };
+        }
+
+        [TestMethod]
+        public void Test_ValidationRulesAreValid()
+        {
+            // Get all the const string schemas from ForgeSchemaHelper.
+            List<FieldInfo> schemas = this.GetAllPublicConstantFields(typeof(ForgeSchemaHelper));
+            Console.WriteLine("Count of unique schemas getting evaluated: " + schemas.Count);
+            int treeCount = 0;
+            
+            // Iterate through each schema to run validations.
+            foreach (FieldInfo fieldInfo in schemas)
+            {
+                Console.WriteLine(fieldInfo.Name);
+                string jsonSchema = (string)fieldInfo.GetRawConstantValue();
+                List<Tuple<string, bool>> jsonTrees = new List<Tuple<string, bool>>();
+
+                // jsonSchema may be deserialized to either a Dictionary<string, ForgeTree> (containing multiple trees), or a single ForgeTree.
+                // Gather all the individual ForgeTree(s) from the schema and cache them in jsonTrees with their expectedResult.
+                try
+                {
+                    Dictionary<string, ForgeTree> forgeTrees = JsonConvert.DeserializeObject<Dictionary<string, ForgeTree>>(jsonSchema);
+                    
+                    foreach (var kvp in forgeTrees)
+                    {
+                        string treeName = kvp.Key;
+                        ForgeTree forgeTree = kvp.Value;
+
+                        if (forgeTree.Tree == null)
+                        {
+                            // Deserialize into Dictionary does not throw exception but will have null "Tree" property if schema is just a ForgeTree.
+                            // Throw exception here to trigger deserializing into ForgeTree directly.
+                            throw new NullReferenceException();
+                        }
+
+                        string jsonSubSchema = JsonConvert.SerializeObject(
+                            forgeTree,
+                            new JsonSerializerSettings
+                            {
+                                DefaultValueHandling = DefaultValueHandling.Ignore, // Prevent default values from getting added to serialized json schema.
+                                Converters = new List<JsonConverter> { new Newtonsoft.Json.Converters.StringEnumConverter() } // Use string enum values instead of numerical.
+                            });
+
+                        // expectedResult is false if this schema/TreeName is blacklisted.
+                        bool expectedResult = !(this.jsonSchemaFailureBlacklist.TryGetValue(fieldInfo.Name, out List<string> list) && list.Contains(treeName));
+                        jsonTrees.Add(new Tuple<string, bool>(jsonSubSchema, expectedResult));
+                    }
+                    Console.WriteLine("DICTIONARY NO THROW");
+                }
+                catch (Exception)
+                {
+                    try
+                    {
+                        // Verify that schema can be deserialized.
+                        JsonConvert.DeserializeObject<ForgeTree>(jsonSchema);
+
+                        // expectedResult is false if this schema/TreeName is blacklisted.
+                        bool expectedResult = !(this.jsonSchemaFailureBlacklist.TryGetValue(fieldInfo.Name, out List<string> list) && list.Contains("NA"));
+                        jsonTrees.Add(new Tuple<string, bool>(jsonSchema, expectedResult));
+                    }
+                    catch (Exception)
+                    {
+                        Assert.Fail("ForgeSchema for property (" + fieldInfo.Name + ") did not deserialize to a ForgeTree or Dictionary<string, ForgeTree>.");
+                    }
+                }
+
+                // Validate each ForgeTree in this schema according to their expectedResult.
+                foreach (var tuple in jsonTrees)
+                {
+                    treeCount++;
+                    string schema = tuple.Item1;
+                    bool expectedResult = tuple.Item2;
+                    this.Validate(jsonSchema: schema, expectedResult: expectedResult);
+                }
+            }
+
+            Console.WriteLine("Count of unique ForgeTrees getting evaluated: " + treeCount);
+        }
+
+        private void Validate(string jsonSchema, bool expectedResult)
+        {
+            JObject schema = JObject.Parse(jsonSchema);
+
+            // Check if the forgeTree schema is valid against the json schema validation rules.
+            bool isValid = schema.IsValid(this.rules, out IList<ValidationError> errors);
+            Console.WriteLine("IsValid: " + isValid + ", ExpectedResult: " + expectedResult);
+
+            foreach (var error in errors)
+            {
+                this.PrintValidationErrors(error);
+                Console.WriteLine(jsonSchema);
+            }
+
+            if (expectedResult)
+            {
+                Assert.IsTrue(isValid);
+            }
+            else
+            {
+                Assert.IsFalse(isValid);
+            }
+        }
+
+        private void PrintValidationErrors (ValidationError error)
+        {
+            Console.WriteLine(error.Message);
+            Console.WriteLine(error.Path);
+            Console.WriteLine(error.ErrorType);
+            Console.WriteLine(error.SchemaBaseUri);
+            Console.WriteLine(error.SchemaId);
+            Console.WriteLine(error.Schema);
+
+            foreach (var child in error.ChildErrors)
+            {
+                this.PrintValidationErrors(child);
+            }
+        }
+
+        private List<FieldInfo> GetAllPublicConstantFields(Type type)
+        {
+            return type
+                .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+                .Where(fi => fi.IsLiteral && !fi.IsInitOnly && fi.FieldType == typeof(string))
+                .ToList();
+        }
+    }
+}

--- a/Forge.TreeWalker.UnitTests/test/ForgeSchemaValidationTests.cs
+++ b/Forge.TreeWalker.UnitTests/test/ForgeSchemaValidationTests.cs
@@ -41,14 +41,14 @@ namespace Forge.TreeWalker.UnitTests
             this.jsonSchemaFailureBlacklist = new Dictionary<string, List<string>>()
             {
                 {
-                    "SubroutineAction_FailsOnActionTreeNodeType",
+                    nameof(ForgeSchemaHelper.SubroutineAction_FailsOnActionTreeNodeType),
                     new List<string>
                     {
                         "RootTree"
                     }
                 },
                 {
-                    "SubroutineAction_FailsOnNoSubroutineAction",
+                    nameof(ForgeSchemaHelper.SubroutineAction_FailsOnNoSubroutineAction),
                     new List<string>
                     {
                         "RootTree"
@@ -102,7 +102,6 @@ namespace Forge.TreeWalker.UnitTests
                         bool expectedResult = !(this.jsonSchemaFailureBlacklist.TryGetValue(fieldInfo.Name, out List<string> list) && list.Contains(treeName));
                         jsonTrees.Add(new Tuple<string, bool>(jsonSubSchema, expectedResult));
                     }
-                    Console.WriteLine("DICTIONARY NO THROW");
                 }
                 catch (Exception)
                 {

--- a/Forge.TreeWalker.UnitTests/test/TreeWalkerUnitTests.cs
+++ b/Forge.TreeWalker.UnitTests/test/TreeWalkerUnitTests.cs
@@ -742,9 +742,9 @@ namespace Forge.TreeWalker.UnitTests
                 string treeNodeKey,
                 dynamic properties,
                 dynamic userContext,
-                CancellationToken token,
                 string treeName,
-                Guid rootSessionId)
+                Guid rootSessionId,
+                CancellationToken token)
             {
                 string serializeProperties = JsonConvert.SerializeObject(properties);
 
@@ -760,9 +760,9 @@ namespace Forge.TreeWalker.UnitTests
                 string treeNodeKey,
                 dynamic properties,
                 dynamic userContext,
-                CancellationToken token,
                 string treeName,
-                Guid rootSessionId)
+                Guid rootSessionId,
+                CancellationToken token)
             {
                 Console.WriteLine(string.Format(
                     "OnAfterVisitNode: SessionId: {0}, TreeNodeKey: {1}, Properties: {2}.",

--- a/Forge.TreeWalker.UnitTests/test/TreeWalkerUnitTests.cs
+++ b/Forge.TreeWalker.UnitTests/test/TreeWalkerUnitTests.cs
@@ -19,25 +19,25 @@ namespace Forge.TreeWalker.UnitTests
     using Forge.DataContracts;
     using Forge.TreeWalker;
     using Forge.TreeWalker.ForgeExceptions;
-
     using Newtonsoft.Json;
 
     [TestClass]
     public class TreeWalkerUnitTests
     {
         private Guid sessionId;
-        private IForgeDictionary forgeState = new ForgeDictionary(new Dictionary<string, object>(), Guid.Empty);
+        private IForgeDictionary forgeState = new ForgeDictionary(new Dictionary<string, object>(), Guid.Empty, Guid.Empty);
         private dynamic UserContext = new System.Dynamic.ExpandoObject();
         private ITreeWalkerCallbacks callbacks;
         private CancellationToken token;
         private TreeWalkerParameters parameters;
         private TreeWalkerSession session;
+        private Dictionary<string, ForgeTree> forgeTrees = new Dictionary<string, ForgeTree>();
 
-        public void TestInitialize(string jsonSchema)
+        public void TestInitialize(string jsonSchema, string treeName = null)
         {
             // Initialize contexts, callbacks, and actions.
             this.sessionId = Guid.NewGuid();
-            this.forgeState = new ForgeDictionary(new Dictionary<string, object>(), this.sessionId);
+            this.forgeState = new ForgeDictionary(new Dictionary<string, object>(), this.sessionId, this.sessionId);
             this.callbacks = new TreeWalkerCallbacks();
             this.token = new CancellationTokenSource().Token;
 
@@ -62,10 +62,22 @@ namespace Forge.TreeWalker.UnitTests
                 this.token)
             {
                 UserContext = this.UserContext,
-                ForgeActionsAssembly = typeof(CollectDiagnosticsAction).Assembly
+                ForgeActionsAssembly = typeof(CollectDiagnosticsAction).Assembly,
+                InitializeSubroutineTree = this.InitializeSubroutineTree,
+                TreeName = treeName
             };
 
             this.session = new TreeWalkerSession(this.parameters);
+        }
+
+        public void TestSubroutineInitialize(string jsonSchema, string treeName = "RootTree")
+        {
+            // Subroutine tests use a ForgeSchema file that deserializes to a Dictionary of TreeName to ForgeTree.
+            this.forgeTrees = JsonConvert.DeserializeObject<Dictionary<string, ForgeTree>>(jsonSchema);
+            ForgeTree forgeTree = this.forgeTrees[treeName];
+            string rootSchema = JsonConvert.SerializeObject(forgeTree);
+
+            this.TestInitialize(rootSchema, treeName);
         }
 
         [TestMethod]
@@ -507,11 +519,220 @@ namespace Forge.TreeWalker.UnitTests
                 "Expected to successfully retrieve the Func output value from the action.");
         }
 
+        [TestMethod]
+        public void Test_SubroutineAction_ConfirmLastActionResponseGetsPersisted_Success()
+        {
+            this.TestSubroutineInitialize(jsonSchema: ForgeSchemaHelper.SubroutineAction_GetLastActionResponse, treeName: "ParentTree");
+
+            // Test - WalkTree to execute a SubroutineAction. Subroutine tree contains an action, defines a RootTreeNodeKey, and queries TreeInput from the schema.
+            //        Confirm the output of the SubroutineAction is the last ActionResponse in the Subroutine tree.
+            string actualStatus = this.session.WalkTree("Root").GetAwaiter().GetResult();
+            Assert.AreEqual("RanToCompletion", actualStatus);
+
+            ActionResponse subroutineActionResponse = this.session.GetOutput("Root_Subroutine");
+            Assert.AreEqual(
+                "Success",
+                subroutineActionResponse.Status,
+                "Expected to successfully retrieve the output value from the action that matches the last action response of the subroutine tree.");
+
+            Assert.AreEqual(
+                10,
+                subroutineActionResponse.StatusCode,
+                "Expected to successfully retrieve the output value from the action that matches the last action response of the subroutine tree.");
+        }
+
+        [TestMethod]
+        public void Test_SubroutineAction_NoActions_Success()
+        {
+            this.TestSubroutineInitialize(jsonSchema: ForgeSchemaHelper.SubroutineAction_NoActions, treeName: "RootTree");
+
+            // Test - WalkTree to execute a SubroutineAction. Subroutine tree contains no Actions. Subroutine tree does not specify RootTreeNodeKey, so expect to visit "Root" be default.
+            //        Confirm the output of the SubroutineAction is the Status of the Subroutine tree walker session.
+            string actualStatus = this.session.WalkTree("Root").GetAwaiter().GetResult();
+            Assert.AreEqual("RanToCompletion", actualStatus);
+
+            ActionResponse subroutineActionResponse = this.session.GetOutput("Root_Subroutine");
+            Assert.AreEqual(
+                "RanToCompletion",
+                subroutineActionResponse.Status,
+                "Expected to successfully retrieve the Status of the subroutine session, since the subroutine tree contained no Actions.");
+        }
+
+        [TestMethod]
+        public void Test_SubroutineAction_ConfirmIntermediatesUsePersistedSessionIdOnRehydration_Success()
+        {
+            this.TestSubroutineInitialize(jsonSchema: ForgeSchemaHelper.SubroutineAction_NoActions, treeName: "RootTree");
+
+            // WalkTree to execute a SubroutineAction.
+            string actualStatus = this.session.WalkTree("Root").GetAwaiter().GetResult();
+            Assert.AreEqual("RanToCompletion", actualStatus);
+
+            ActionResponse subroutineActionResponse = this.session.GetOutput("Root_Subroutine");
+            Assert.AreEqual(
+                "RanToCompletion",
+                subroutineActionResponse.Status,
+                "Expected to successfully retrieve the Status of the subroutine session, since the subroutine tree contained no Actions.");
+
+            // Cache the original subroutine SessionId to check against later.
+            SubroutineIntermediates subroutineIntermediates = this.forgeState.GetValue<SubroutineIntermediates>("Root_Subroutine" + TreeWalkerSession.IntermediatesSuffix).GetAwaiter().GetResult();
+            Guid subroutineSessionId = subroutineIntermediates.SessionId;
+
+            // Brain surgery to make it look like we failed over during SubroutineAction before the ActionResponse was persisted.
+            this.forgeState.Set<ActionResponse>("Root_Subroutine" + TreeWalkerSession.ActionResponseSuffix, null).GetAwaiter().GetResult();
+            this.session = new TreeWalkerSession(this.session.Parameters);
+
+            actualStatus = this.session.WalkTree("Root").GetAwaiter().GetResult();
+            Assert.AreEqual("RanToCompletion", actualStatus);
+
+            // Test - Confirm the SubroutineIntermediates.SessionId is persisted and gets re-used on rehydration.
+            subroutineIntermediates = this.forgeState.GetValue<SubroutineIntermediates>("Root_Subroutine" + TreeWalkerSession.IntermediatesSuffix).GetAwaiter().GetResult();
+            Assert.AreEqual(subroutineSessionId, subroutineIntermediates.SessionId);
+        }
+
+        [TestMethod]
+        public void Test_SubroutineAction_ParallelSubroutineActions_Success()
+        {
+            this.TestSubroutineInitialize(jsonSchema: ForgeSchemaHelper.SubroutineAction_ParallelSubroutineActions, treeName: "RootTree");
+
+            // Test - WalkTree to execute a Subroutine node with 2 SubroutineActions and a regular Action in parallel.
+            //        Confirm parallel actions execute successfully.
+            string actualStatus = this.session.WalkTree("Root").GetAwaiter().GetResult();
+            Assert.AreEqual("RanToCompletion", actualStatus);
+
+            ActionResponse subroutineActionResponse = this.session.GetOutput("Root_Subroutine_One");
+            Assert.AreEqual(
+                "TestValueOne",
+                subroutineActionResponse.Status,
+                "Expected to successfully retrieve the output value from the action that matches the last action response of the subroutine tree.");
+
+            subroutineActionResponse = this.session.GetOutput("Root_Subroutine_Two");
+            Assert.AreEqual(
+                "TestValueTwo",
+                subroutineActionResponse.Status,
+                "Expected to successfully retrieve the output value from the action that matches the last action response of the subroutine tree.");
+
+            ActionResponse actionResponse = this.session.GetOutput("Root_CollectDiagnosticsAction");
+            Assert.AreEqual(
+                "Success",
+                actionResponse.Status,
+                "Expected to successfully read ActionResponse.Status.");
+        }
+
+        [TestMethod]
+        public void Test_SubroutineAction_FailsOnActionTreeNodeType_Failure()
+        {
+            this.TestSubroutineInitialize(jsonSchema: ForgeSchemaHelper.SubroutineAction_FailsOnActionTreeNodeType, treeName: "RootTree");
+
+            // Test - WalkTree and fail to execute an Action type node containing a SubroutineAction.
+            string actual;
+            Assert.ThrowsException<ArgumentException>(() =>
+            {
+                actual = this.session.WalkTree("Root").GetAwaiter().GetResult();
+            }, "Expected WalkTree to fail because the schema contained a Property that does not exist in ActionDefinition.InputType.");
+
+            actual = this.session.Status;
+            Assert.AreEqual(
+                "Failed",
+                actual,
+                "Expected WalkTree to fail because the schema contained a Property that does not exist in ActionDefinition.InputType.");
+        }
+
+        [TestMethod]
+        public void Test_SubroutineAction_FailsOnNoSubroutineAction_Failure()
+        {
+            this.TestSubroutineInitialize(jsonSchema: ForgeSchemaHelper.SubroutineAction_FailsOnNoSubroutineAction, treeName: "RootTree");
+
+            // Test - WalkTree and fail to execute a Subroutine type node that does not contain at least one SubroutineAction.
+            string actual;
+            Assert.ThrowsException<ArgumentException>(() =>
+            {
+                actual = this.session.WalkTree("Root").GetAwaiter().GetResult();
+            }, "Expected WalkTree to fail because the schema contained a Property that does not exist in ActionDefinition.InputType.");
+
+            actual = this.session.Status;
+            Assert.AreEqual(
+                "Failed",
+                actual,
+                "Expected WalkTree to fail because the schema contained a Property that does not exist in ActionDefinition.InputType.");
+        }
+
+        [TestMethod]
+        public void Test_Cycles_Success()
+        {
+            this.TestInitialize(jsonSchema: ForgeSchemaHelper.CycleSchema);
+
+            // Test - WalkTree that revisits a node multiple times.
+            //        Inside the Action, we confirm that GetPreviousActionResponse gets persisted and Action Intermediates get wiped.
+            string actualStatus = this.session.WalkTree("Root").GetAwaiter().GetResult();
+            Assert.AreEqual("RanToCompletion_NoChildMatched", actualStatus);
+
+            ActionResponse actionResponse = this.session.GetLastActionResponse();
+            Assert.AreEqual(
+                3,
+                (int)actionResponse.Output,
+                "Expected to successfully retrieve the output value from the action that matches the last action response of the subroutine tree.");
+        }
+
+        [TestMethod]
+        public void Test_Cycles_RevisitSubroutineActionUsesDifferentSessionId_Success()
+        {
+            this.TestSubroutineInitialize(jsonSchema: ForgeSchemaHelper.Cycle_SubroutineActionUsesDifferentSessionId);
+
+            // Test - WalkTree that revisits a Subroutine node multiple times.
+            //        Confirm different SessionIds get used each time we revisit the SubroutineAction.
+            string actualStatus = this.session.WalkTree("Root").GetAwaiter().GetResult();
+            Assert.AreEqual("RanToCompletion_NoChildMatched", actualStatus);
+
+            string rootSessionId = this.session.Parameters.RootSessionId.ToString();
+            ActionResponse previousActionResponse = this.forgeState.GetValue<ActionResponse>("Root_Subroutine" + TreeWalkerSession.PreviousActionResponseSuffix).GetAwaiter().GetResult();
+            ActionResponse actionResponse = this.session.GetOutput("Root_Subroutine");
+
+            Assert.AreNotEqual(
+                previousActionResponse.Status,
+                actionResponse.Status,
+                "Expected to successfully retrieve the output value from the action that matches the last action response of the subroutine tree.");
+
+            Assert.AreNotEqual(
+                rootSessionId,
+                previousActionResponse.Status);
+
+            Assert.AreNotEqual(
+                rootSessionId,
+                actionResponse.Status);
+        }
+
+        /// <summary>
+        /// Used to test ExternalExecutors.
+        /// </summary>
         private static async Task<object> External(string expression, CancellationToken token)
         {
             // External executes the expression and returns.
             await Task.Delay(1, token);
             return expression + "_Executed";
+        }
+
+        /// <summary>
+        /// Used to test SubroutineActions.
+        /// </summary>
+        private TreeWalkerSession InitializeSubroutineTree(SubroutineInput subroutineInput, Guid subroutineSessionId, TreeWalkerParameters parentParameters)
+        {
+            string jsonSchema = JsonConvert.SerializeObject(forgeTrees[subroutineInput.TreeName]);
+            TreeWalkerParameters subroutineParameters = new TreeWalkerParameters(
+                subroutineSessionId,
+                jsonSchema,
+                new ForgeDictionary(new Dictionary<string, object>(), parentParameters.RootSessionId, subroutineSessionId),
+                this.callbacks,
+                this.token)
+            {
+                UserContext = this.UserContext,
+                ForgeActionsAssembly = typeof(CollectDiagnosticsAction).Assembly,
+                InitializeSubroutineTree = this.InitializeSubroutineTree,
+                RootSessionId = parentParameters.RootSessionId,
+                TreeName = subroutineInput.TreeName,
+                TreeInput = subroutineInput.TreeInput
+            };
+
+            return new TreeWalkerSession(subroutineParameters);
         }
 
         private sealed class TreeWalkerCallbacks : ITreeWalkerCallbacks
@@ -521,7 +742,9 @@ namespace Forge.TreeWalker.UnitTests
                 string treeNodeKey,
                 dynamic properties,
                 dynamic userContext,
-                CancellationToken token)
+                CancellationToken token,
+                string treeName,
+                Guid rootSessionId)
             {
                 string serializeProperties = JsonConvert.SerializeObject(properties);
 
@@ -537,7 +760,9 @@ namespace Forge.TreeWalker.UnitTests
                 string treeNodeKey,
                 dynamic properties,
                 dynamic userContext,
-                CancellationToken token)
+                CancellationToken token,
+                string treeName,
+                Guid rootSessionId)
             {
                 Console.WriteLine(string.Format(
                     "OnAfterVisitNode: SessionId: {0}, TreeNodeKey: {1}, Properties: {2}.",
@@ -582,6 +807,11 @@ namespace Forge.TreeWalker.UnitTests
             public Task<T> GetIntermediates<T>()
             {
                 return this.actionContext.GetIntermediates<T>();
+            }
+
+            public Task<ActionResponse> GetPreviousActionResponse()
+            {
+                return this.actionContext.GetPreviousActionResponse();
             }
         }
 
@@ -703,12 +933,15 @@ namespace Forge.TreeWalker.UnitTests
             public long[] LongArray { get; set; }
             public Func<bool> BoolDelegate { get; set; }
             public Func<Task<bool>> BoolDelegateAsync { get; set; }
+            public Dictionary<string, string> StringDictionary { get; set; }
+            public object DynamicObject { get; set; }
         }
 
         public class FooActionObject
         {
             public string Name { get; set; }
             public string Value { get; set; }
+            public int IntPropertyInObject { get; set; }
         }
 
         [ForgeAction(InputType: typeof(FooActionInput_UnexpectedField))]
@@ -757,6 +990,46 @@ namespace Forge.TreeWalker.UnitTests
             public bool BoolProperty { get; set; }
 
             public FooActionInput_NonEmptyConstructor(int unexpectedParameter) {}
+        }
+
+        /// <summary>
+        /// This action increases counters each time it is visited from the same TreeActionKey in the same SessionId.
+        /// It persists these counters in the ActionResponse/PreviousActionResponse.
+        /// This tests CommitCurrentTreeNode revisit/cycle behavior.
+        /// </summary>
+        [ForgeAction]
+        public class RevisitAction : BaseCommonAction
+        {
+            public override async Task<ActionResponse> RunAction()
+            {
+                // Confirm that intermediates are getting cleared every time we revisit the node, despite us increasing the counter.
+                int intermediates = await this.GetIntermediates<int>();
+                Assert.AreEqual(0, intermediates);
+
+                intermediates++;
+                await this.CommitIntermediates<int>(intermediates);
+
+                // GetPreviousActionResponse, increase the Output counter by one, and return.
+                ActionResponse actionResponse = await this.GetPreviousActionResponse() ?? new ActionResponse() { Status = "Success", Output = 0 };
+                actionResponse.Output = (int)actionResponse.Output + 1;
+
+                Console.WriteLine(string.Format(
+                    "RevisitAction - SessionId: {0}, TreeNodeKey: {1}, ActionResponse.Output: {2}.",
+                    this.SessionId,
+                    this.TreeNodeKey,
+                    actionResponse.Output));
+
+                return actionResponse;
+            }
+        }
+
+        [ForgeAction]
+        public class ReturnSessionIdAction : BaseCommonAction
+        {
+            public override Task<ActionResponse> RunAction()
+            {
+                return Task.FromResult(new ActionResponse() { Status = this.SessionId.ToString() });
+            }
         }
     }
 }

--- a/Forge.TreeWalker/Forge.TreeWalker.csproj
+++ b/Forge.TreeWalker/Forge.TreeWalker.csproj
@@ -80,6 +80,7 @@
     <Compile Include="src\IForgeDictionary.cs" />
     <Compile Include="src\ITreeSession.cs" />
     <Compile Include="src\ITreeWalkerCallbacks.cs" />
+    <Compile Include="src\SubroutineAction.cs" />
     <Compile Include="src\TreeWalkerParameters.cs" />
     <Compile Include="src\TreeWalkerSession.cs" />
   </ItemGroup>

--- a/Forge.TreeWalker/contracts/ForgeSchemaValidationRules.json
+++ b/Forge.TreeWalker/contracts/ForgeSchemaValidationRules.json
@@ -1,193 +1,281 @@
 {
-  "type": "object",
-  "definitions": {
-    "TreeDefinition": {
-      "type": "object",
-      "patternProperties": {
-        ".*?": {
-          "$ref": "#/definitions/TreeNodeDefinition"
+    "type": "object",
+    "properties": {
+        "Tree": {
+            "$ref": "#/definitions/TreeDefinition"
+        },
+        "RootTreeNodeKey": {
+            "type": "string"
         }
-      }
     },
-    "TreeNodeDefinition": {
-      "oneOf": [
-        {
-          "$ref": "#/definitions/SelectionTypeNodeDefinition"
-        },
-        {
-          "$ref": "#/definitions/ActionTypeNodeDefinition"
-        },
-        {
-          "$ref": "#/definitions/LeafTypeNodeDefinition"
-        }
-      ]
-    },
-    "SelectionTypeNodeDefinition": {
-      "type": "object",
-      "properties": {
-        "Type": {
-          "type": "string",
-          "enum": [ "Selection" ]
-        },
-        "ChildSelector": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ChildSelectorDefinition"
-          },
-          "minItems": 1
-        },
-        "Properties": {
-          "type": "object"
-        }
-      },
-      "additionalProperties": false,
-      "required": [ "Type" ]
-    },
-    "ActionTypeNodeDefinition": {
-      "type": "object",
-      "properties": {
-        "Type": {
-          "type": "string",
-          "enum": [ "Action" ]
-        },
-        "Timeout": {
-          "type": [ "number", "string" ]
-        },
-        "Actions": {
-          "patternProperties": {
-            ".*?": {
-              "$ref": "#/definitions/ActionDefinition"
+    "additionalProperties": false,
+    "definitions": {
+        "TreeDefinition": {
+            "type": "object",
+            "patternProperties": {
+                ".*?": {
+                    "$ref": "#/definitions/TreeNodeDefinition"
+                }
             }
-          },
-          "minProperties": 1
         },
-        "ChildSelector": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ChildSelectorDefinition"
-          },
-          "minItems": 1
+        "TreeNodeDefinition": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/SelectionTypeNodeDefinition"
+                },
+                {
+                    "$ref": "#/definitions/ActionTypeNodeDefinition"
+                },
+                {
+                    "$ref": "#/definitions/LeafTypeNodeDefinition"
+                },
+                {
+                    "$ref": "#/definitions/SubroutineTypeNodeDefinition"
+                }
+            ]
         },
-        "Properties": {
-          "type": "object"
-        }
-      },
-      "additionalProperties": false,
-      "required": [ "Type", "Actions" ]
-    },
-    "LeafTypeNodeDefinition": {
-      "type": "object",
-      "properties": {
-        "Type": {
-          "type": "string",
-          "enum": [ "Leaf" ]
+        "SelectionTypeNodeDefinition": {
+            "type": "object",
+            "properties": {
+                "Type": {
+                    "type": "string",
+                    "enum": [ "Selection" ]
+                },
+                "ChildSelector": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ChildSelectorDefinition"
+                    },
+                    "minItems": 1
+                },
+                "Properties": {
+                    "type": "object"
+                }
+            },
+            "additionalProperties": false,
+            "required": [ "Type", "ChildSelector" ]
         },
-        "Actions": {
-          "patternProperties": {
-            ".*?": {
-              "$ref": "#/definitions/LeafNodeSummaryActionDefinition"
-            }
-          },
-          "minProperties": 1,
-          "maxProperties": 1
+        "ActionTypeNodeDefinition": {
+            "type": "object",
+            "properties": {
+                "Type": {
+                    "type": "string",
+                    "enum": [ "Action" ]
+                },
+                "Timeout": {
+                    "type": [ "number", "string" ]
+                },
+                "Actions": {
+                    "allOf": [
+                        {
+                            "not": {
+                                "patternProperties": {
+                                    ".*?": {
+                                        "$ref": "#/definitions/SubroutineActionDefinition"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "patternProperties": {
+                                ".*?": {
+                                    "$ref": "#/definitions/ActionDefinition"
+                                }
+                            },
+                            "minProperties": 1
+                        }
+                    ]
+                },
+                "ChildSelector": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ChildSelectorDefinition"
+                    },
+                    "minItems": 1
+                },
+                "Properties": {
+                    "type": "object"
+                }
+            },
+            "additionalProperties": false,
+            "required": [ "Type", "Actions" ]
         },
-        "Properties": {
-          "type": "object"
-        }
-      },
-      "additionalProperties": false,
-      "required": [ "Type" ]
-    },
-    "ChildSelectorDefinition": {
-      "type": "object",
-      "properties": {
-        "Label": {
-          "type": "string"
+        "LeafTypeNodeDefinition": {
+            "type": "object",
+            "properties": {
+                "Type": {
+                    "type": "string",
+                    "enum": [ "Leaf" ]
+                },
+                "Actions": {
+                    "patternProperties": {
+                        ".*?": {
+                            "$ref": "#/definitions/LeafNodeSummaryActionDefinition"
+                        }
+                    },
+                    "minProperties": 1,
+                    "maxProperties": 1
+                },
+                "Properties": {
+                    "type": "object"
+                }
+            },
+            "additionalProperties": false,
+            "required": [ "Type" ]
         },
-        "ShouldSelect": {
-          "type": "string"
+        "SubroutineTypeNodeDefinition": {
+            "type": "object",
+            "properties": {
+                "Type": {
+                    "type": "string",
+                    "enum": [ "Subroutine" ]
+                },
+                "Timeout": {
+                    "type": [ "number", "string" ]
+                },
+                "Actions": {
+                    "type": "object",
+                    "minProperties": 1,
+                    "patternProperties": {
+                        ".*?": {
+                            "if": {
+                                "$ref": "#/definitions/SubroutineActionDefinition"
+                            },
+                            "else": {
+                                "$ref": "#/definitions/ActionDefinition"
+                            }
+                        }
+                    }
+                },
+                "ChildSelector": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ChildSelectorDefinition"
+                    },
+                    "minItems": 1
+                },
+                "Properties": {
+                    "type": "object"
+                }
+            },
+            "additionalProperties": false,
+            "required": [ "Type", "Actions" ]
         },
-        "Child": {
-          "type": "string"
-        }
-      },
-      "additionalProperties": false,
-      "required": [ "Label", "Child" ]
-    },
-    "RetryPolicy": {
-      "type": "object",
-      "properties": {
-        "Type": {
-          "type": "string",
-          "enum": [ "None", "FixedInterval", "ExponentialBackoff" ]
-        },
-        "MinBackoffMs": {
-          "type": "number"
-        },
-        "MaxBackoffMs": {
-          "type": "number"
-        }
-      },
-      "required": [ "Type" ]
-    },
-    "ActionDefinition": {
-      "type": "object",
-      "properties": {
-        "Action": {
-          "type": "string"
-        },
-        "Input": {
-          "type": "object"
-        },
-        "Properties": {
-          "type": "object"
-        },
-        "Timeout": {
-          "type": [ "number", "string" ]
-        },
-        "ContinuationOnTimeout": {
-          "type": "boolean"
+        "ChildSelectorDefinition": {
+            "type": "object",
+            "properties": {
+                "Label": {
+                    "type": "string"
+                },
+                "ShouldSelect": {
+                    "type": "string"
+                },
+                "Child": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "required": [ "Label", "Child" ]
         },
         "RetryPolicy": {
-          "$ref": "#/definitions/RetryPolicy"
-        },
-        "ContinuationOnRetryExhaustion": {
-          "type": "boolean"
-        }
-      },
-      "additionalProperties": false,
-      "required": [ "Action" ]
-    },
-    "LeafNodeSummaryActionDefinition": {
-      "type": "object",
-      "properties": {
-        "Action": {
-          "enum": [ "LeafNodeSummaryAction" ]
-        },
-        "Input": {
-          "type": [ "object", "string" ],
-          "properties": {
-            "Status": {
-              "type": "string"
+            "type": "object",
+            "properties": {
+                "Type": {
+                    "type": "string",
+                    "enum": [ "None", "FixedInterval", "ExponentialBackoff" ]
+                },
+                "MinBackoffMs": {
+                    "type": "number"
+                },
+                "MaxBackoffMs": {
+                    "type": "number"
+                }
             },
-            "StatusCode": {
-              "type": [ "number", "string" ]
+            "required": [ "Type" ]
+        },
+        "ActionDefinition": {
+            "type": "object",
+            "properties": {
+                "Action": {
+                    "type": "string"
+                },
+                "Input": {
+                    "type": "object"
+                },
+                "Properties": {
+                    "type": "object"
+                },
+                "Timeout": {
+                    "type": [ "number", "string" ]
+                },
+                "ContinuationOnTimeout": {
+                    "type": "boolean"
+                },
+                "RetryPolicy": {
+                    "$ref": "#/definitions/RetryPolicy"
+                },
+                "ContinuationOnRetryExhaustion": {
+                    "type": "boolean"
+                }
             },
-            "Output": {
-              "type": [ "object", "string" ]
-            }
-          },
-          "additionalProperties": false
+            "additionalProperties": false,
+            "required": [ "Action" ]
+        },
+        "LeafNodeSummaryActionDefinition": {
+            "type": "object",
+            "properties": {
+                "Action": {
+                    "enum": [ "LeafNodeSummaryAction" ]
+                },
+                "Input": {
+                    "type": [ "object", "string" ],
+                    "properties": {
+                        "Status": {
+                            "type": "string"
+                        },
+                        "StatusCode": {
+                            "type": [ "number", "string" ]
+                        },
+                        "Output": {
+                            "type": [ "object", "string" ]
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false,
+            "required": [ "Action", "Input" ]
+        },
+        "SubroutineActionDefinition": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/ActionDefinition"
+                },
+                {
+                    "properties": {
+                        "Action": {
+                            "enum": [ "SubroutineAction" ]
+                        },
+                        "Input": {
+                            "type": [ "object" ],
+                            "properties": {
+                                "TreeName": {
+                                    "type": "string"
+                                },
+                                "TreeInput": {
+                                    "type": [ "object", "string" ]
+                                },
+                                "TreeFilePath": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [ "TreeName" ]
+                        }
+                    },
+                    "required": [ "Action", "Input" ]
+                }
+            ]
         }
-      },
-      "additionalProperties": false,
-      "required": [ "Action", "Input" ]
     }
-  },
-  "properties": {
-    "Tree": {
-      "$ref": "#/definitions/TreeDefinition"
-    }
-  },
-  "additionalProperties": false
 }

--- a/Forge.TreeWalker/contracts/ForgeTree.cs
+++ b/Forge.TreeWalker/contracts/ForgeTree.cs
@@ -9,7 +9,6 @@
 
 namespace Forge.DataContracts
 {
-    using System;
     using System.Collections.Generic;
     using System.Runtime.Serialization;
 
@@ -25,6 +24,12 @@ namespace Forge.DataContracts
         /// </summary>
         [DataMember]
         public Dictionary<string, TreeNode> Tree { get; set; }
+
+        /// <summary>
+        /// The root TreeNodeKey that should be visited first when walking the tree.
+        /// </summary>
+        [DataMember]
+        public string RootTreeNodeKey { get; set; } = "Root";
     }
 
     /// <summary>
@@ -247,6 +252,13 @@ namespace Forge.DataContracts
         /// This represents an end state in tree.
         /// </summary>
         [EnumMember]
-        Leaf = 3
+        Leaf = 3,
+
+        /// <summary>
+        /// Subroutine type node.
+        /// This node contains at least one SubroutineAction.
+        /// </summary>
+        [EnumMember]
+        Subroutine = 4
     }
 }

--- a/Forge.TreeWalker/src/ExpressionExecutor.cs
+++ b/Forge.TreeWalker/src/ExpressionExecutor.cs
@@ -49,13 +49,15 @@ namespace Forge.TreeWalker
         /// <param name="userContext">The dynamic user context.</param>
         /// <param name="dependencies">Type dependencies required to compile the schema. Can be null if no external dependencies required.</param>
         /// <param name="scriptCache">Script cache used to cache and re-use compiled Roslyn scripts.</param>
-        public ExpressionExecutor(ITreeSession session, object userContext, List<Type> dependencies, ConcurrentDictionary<string, Script<object>> scriptCache)
+        /// <param name="treeInput">The dynamic TreeInput object for this tree walking session.</param>
+        public ExpressionExecutor(ITreeSession session, object userContext, List<Type> dependencies, ConcurrentDictionary<string, Script<object>> scriptCache, object treeInput)
         {
             this.dependencies = dependencies;
             this.parameters = new CodeGenInputParams
             {
                 UserContext = userContext,
-                Session = session
+                Session = session,
+                TreeInput = treeInput
             };
             this.scriptCache = scriptCache ?? new ConcurrentDictionary<string, Script<object>>();
             this.Initialize();
@@ -67,8 +69,9 @@ namespace Forge.TreeWalker
         /// <param name="session">The tree session.</param>
         /// <param name="userContext">The dynamic user context.</param>
         /// <param name="dependencies">Type dependencies required to compile the schema. Can be null if no external dependencies required.</param>
-        public ExpressionExecutor(ITreeSession session, object userContext, List<Type> dependencies)
-            : this(session, userContext, dependencies, new ConcurrentDictionary<string, Script<object>>())
+        /// <param name="treeInput">The dynamic TreeInput object for this tree walking session.</param>
+        public ExpressionExecutor(ITreeSession session, object userContext, List<Type> dependencies, object treeInput)
+            : this(session, userContext, dependencies, new ConcurrentDictionary<string, Script<object>>(), treeInput)
         {
         }
 
@@ -150,6 +153,13 @@ namespace Forge.TreeWalker
             /// The ITreeSession interface that holds accessor methods into the forgeState dictionary that can be referenced in the schema.
             /// </summary>
             public ITreeSession Session { get; set; }
+
+            /// <summary>
+            /// The dynamic TreeInput object for this tree walking session.
+            /// This is passed in to the root/parent session by the App.
+            /// For Subroutines, this is evaluated from the SubroutineInput on the schema.
+            /// </summary>
+            public dynamic TreeInput { get; set; }
         }
     }
 }

--- a/Forge.TreeWalker/src/ExpressionExecutor.cs
+++ b/Forge.TreeWalker/src/ExpressionExecutor.cs
@@ -69,9 +69,30 @@ namespace Forge.TreeWalker
         /// <param name="session">The tree session.</param>
         /// <param name="userContext">The dynamic user context.</param>
         /// <param name="dependencies">Type dependencies required to compile the schema. Can be null if no external dependencies required.</param>
-        /// <param name="treeInput">The dynamic TreeInput object for this tree walking session.</param>
-        public ExpressionExecutor(ITreeSession session, object userContext, List<Type> dependencies, object treeInput)
-            : this(session, userContext, dependencies, new ConcurrentDictionary<string, Script<object>>(), treeInput)
+        /// <param name="scriptCache">Script cache used to cache and re-use compiled Roslyn scripts.</param>
+        public ExpressionExecutor(ITreeSession session, object userContext, List<Type> dependencies, ConcurrentDictionary<string, Script<object>> scriptCache)
+            : this(session, userContext, dependencies, scriptCache, null)
+        {
+        }
+
+        /// <summary>
+        /// Instantiates the ExpressionExecutor class with objects that can be referenced in the schema.
+        /// </summary>
+        /// <param name="session">The tree session.</param>
+        /// <param name="userContext">The dynamic user context.</param>
+        /// <param name="dependencies">Type dependencies required to compile the schema. Can be null if no external dependencies required.</param>
+        public ExpressionExecutor(ITreeSession session, object userContext, List<Type> dependencies)
+            : this(session, userContext, dependencies, new ConcurrentDictionary<string, Script<object>>())
+        {
+        }
+
+        /// <summary>
+        /// Instantiates the ExpressionExecutor class with objects that can be referenced in the schema.
+        /// </summary>
+        /// <param name="session">The tree session.</param>
+        /// <param name="userContext">The dynamic user context.</param>
+        public ExpressionExecutor(ITreeSession session, object userContext)
+            : this(session, userContext, null)
         {
         }
 

--- a/Forge.TreeWalker/src/ForgeDictionary.cs
+++ b/Forge.TreeWalker/src/ForgeDictionary.cs
@@ -20,11 +20,6 @@ namespace Forge.TreeWalker
     public class ForgeDictionary : IForgeDictionary
     {
         /// <summary>
-        /// The unique identifier for this session.
-        /// </summary>
-        public Guid SessionId { get; set; }
-
-        /// <summary>
         /// The key prefix that should precede the keys when using the forgeStateTable.
         /// This ensures the scope of the table is limited to the current SessionId.
         /// </summary>
@@ -41,12 +36,12 @@ namespace Forge.TreeWalker
         /// ForgeDictionary Constructor.
         /// </summary>
         /// <param name="forgeStateTable">The forge state table dictionary object.</param>
+        /// <param name="rootSessionId">The unique identifier for the root/parent session.</param>
         /// <param name="sessionId">The unique identifier for this session.</param>
-        public ForgeDictionary(IDictionary<string, object> forgeStateTable, Guid sessionId)
+        public ForgeDictionary(IDictionary<string, object> forgeStateTable, Guid rootSessionId, Guid sessionId)
         {
             this.forgeStateTable = forgeStateTable;
-            this.SessionId = sessionId;
-            this.keyPrefix = this.SessionId + "_";
+            this.UpdateKeyPrefix(rootSessionId, sessionId);
         }
 
         /// <summary>
@@ -160,6 +155,33 @@ namespace Forge.TreeWalker
             {
                 this.forgeStateTable.Remove(this.keyPrefix + key);
             }
+        }
+
+        /// <summary>
+        /// Updates the key prefix.
+        /// Note: The KeyPrefix should always precede the key when using the forgeStateTable to limit the scope to the current SessionId.
+        /// </summary>
+        /// <param name="rootSessionId">The unique identifier for the root/parent session.</param>
+        /// <param name="sessionId">The unique identifier for this session.</param>
+        public void UpdateKeyPrefix(Guid rootSessionId, Guid sessionId)
+        {
+            if (rootSessionId == sessionId)
+            {
+                // For backwards compatibility, the parent session will maintain the existing key format: <SessionId>_
+                this.keyPrefix = rootSessionId + "_";
+            }
+            else
+            {
+                this.keyPrefix = rootSessionId + "_" + sessionId + "_";
+            }
+        }
+
+        /// <summary>
+        /// Gets the key prefix.
+        /// </summary>
+        public string GetKeyPrefix()
+        {
+            return this.keyPrefix;
         }
     }
 }

--- a/Forge.TreeWalker/src/IForgeDictionary.cs
+++ b/Forge.TreeWalker/src/IForgeDictionary.cs
@@ -20,11 +20,6 @@ namespace Forge.TreeWalker
     public interface IForgeDictionary
     {
         /// <summary>
-        /// The unique identifier for this session.
-        /// </summary>
-        Guid SessionId { get; set; }
-
-        /// <summary>
         /// Sets an element with the provided key and value to the backing store.
         /// </summary>
         /// <param name="key">The key of the element to set.</param>
@@ -56,5 +51,18 @@ namespace Forge.TreeWalker
         /// </summary>
         /// <param name="keys">The list of keys to remove.</param>
         Task RemoveKeys(List<string> keys);
+
+        /// <summary>
+        /// Updates the key prefix.
+        /// Note: The KeyPrefix should always precede the key when using the forgeStateTable to limit the scope to the current SessionId.
+        /// </summary>
+        /// <param name="rootSessionId">The unique identifier for the root/parent session.</param>
+        /// <param name="sessionId">The unique identifier for this session.</param>
+        void UpdateKeyPrefix(Guid rootSessionId, Guid sessionId);
+
+        /// <summary>
+        /// Gets the key prefix.
+        /// </summary>
+        string GetKeyPrefix();
     }
 }

--- a/Forge.TreeWalker/src/ITreeSession.cs
+++ b/Forge.TreeWalker/src/ITreeSession.cs
@@ -9,7 +9,6 @@
 
 namespace Forge.TreeWalker
 {
-    using System;
     using System.Threading.Tasks;
 
     /// <summary>

--- a/Forge.TreeWalker/src/ITreeWalkerCallbacks.cs
+++ b/Forge.TreeWalker/src/ITreeWalkerCallbacks.cs
@@ -10,8 +10,6 @@
 namespace Forge.TreeWalker
 {
     using System;
-    using System.Collections.Generic;
-    using System.Dynamic;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -28,7 +26,9 @@ namespace Forge.TreeWalker
         /// <param name="properties">The additional properties for this node.</param>
         /// <param name="userContext">The dynamic user-defined context object.</param>
         /// <param name="token">The cancellation token.</param>
-        Task BeforeVisitNode(Guid sessionId, string treeNodeKey, dynamic properties, object userContext, CancellationToken token);
+        /// <param name="treeName">The name of the ForgeTree in the JsonSchema.</param>
+        /// <param name="rootSessionId">The unique identifier for the root/parent tree walking session.</param>
+        Task BeforeVisitNode(Guid sessionId, string treeNodeKey, dynamic properties, object userContext, CancellationToken token, string treeName, Guid rootSessionId);
 
         /// <summary>
         /// The callback Task that is awaited after visiting each node.
@@ -38,6 +38,8 @@ namespace Forge.TreeWalker
         /// <param name="properties">The additional properties for this node.</param>
         /// <param name="userContext">The dynamic user-defined context object.</param>
         /// <param name="token">The cancellation token.</param>
-        Task AfterVisitNode(Guid sessionId, string treeNodeKey, dynamic properties, object userContext, CancellationToken token);
+        /// <param name="treeName">The name of the ForgeTree in the JsonSchema.</param>
+        /// <param name="rootSessionId">The unique identifier for the root/parent tree walking session.</param>
+        Task AfterVisitNode(Guid sessionId, string treeNodeKey, dynamic properties, object userContext, CancellationToken token, string treeName, Guid rootSessionId);
     }
 }

--- a/Forge.TreeWalker/src/ITreeWalkerCallbacks.cs
+++ b/Forge.TreeWalker/src/ITreeWalkerCallbacks.cs
@@ -25,10 +25,10 @@ namespace Forge.TreeWalker
         /// <param name="treeNodeKey">The key of the current tree node being visited by Forge.</param>
         /// <param name="properties">The additional properties for this node.</param>
         /// <param name="userContext">The dynamic user-defined context object.</param>
-        /// <param name="token">The cancellation token.</param>
         /// <param name="treeName">The name of the ForgeTree in the JsonSchema.</param>
         /// <param name="rootSessionId">The unique identifier for the root/parent tree walking session.</param>
-        Task BeforeVisitNode(Guid sessionId, string treeNodeKey, dynamic properties, object userContext, CancellationToken token, string treeName, Guid rootSessionId);
+        /// <param name="token">The cancellation token.</param>
+        Task BeforeVisitNode(Guid sessionId, string treeNodeKey, dynamic properties, object userContext, string treeName, Guid rootSessionId, CancellationToken token);
 
         /// <summary>
         /// The callback Task that is awaited after visiting each node.
@@ -37,9 +37,9 @@ namespace Forge.TreeWalker
         /// <param name="treeNodeKey">The key of the current tree node being visited by Forge.</param>
         /// <param name="properties">The additional properties for this node.</param>
         /// <param name="userContext">The dynamic user-defined context object.</param>
-        /// <param name="token">The cancellation token.</param>
         /// <param name="treeName">The name of the ForgeTree in the JsonSchema.</param>
         /// <param name="rootSessionId">The unique identifier for the root/parent tree walking session.</param>
-        Task AfterVisitNode(Guid sessionId, string treeNodeKey, dynamic properties, object userContext, CancellationToken token, string treeName, Guid rootSessionId);
+        /// <param name="token">The cancellation token.</param>
+        Task AfterVisitNode(Guid sessionId, string treeNodeKey, dynamic properties, object userContext, string treeName, Guid rootSessionId, CancellationToken token);
     }
 }

--- a/Forge.TreeWalker/src/SubroutineAction.cs
+++ b/Forge.TreeWalker/src/SubroutineAction.cs
@@ -1,0 +1,113 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="SubroutineAction.cs" company="Microsoft">
+//     Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+// <summary>
+//     The SubroutineAction class.
+// </summary>
+//-----------------------------------------------------------------------
+
+namespace Forge.TreeWalker
+{
+    using System;
+    using System.Threading.Tasks;
+
+    using Forge.Attributes;
+
+    /// <summary>
+    /// The SubroutineAction is a native Forge action that walks a TreeWalkerSession.
+    /// This action performs the following steps:
+    ///   1. Rehydrates the Subroutine's SessionId if previously persisted.
+    ///   2. Gets an initialized TreeWalkerSession for this Subroutine from the App, passing in the SubroutineInput from the schema and Subroutine SessionId.
+    ///   3. Explicitly calls UpdateKeyPrefix on the ForgeState with the updated Subroutine SessionId.
+    ///   4. Walks the tree starting at the CurrentTreeNode if persisted, otherwise RootTreeNodeKey if given, otherwise "Root" as default.
+    ///   5. Returns the Subroutine's last ActionResponse if available, otherwise returns the tree walker session Status.
+    /// </summary>
+    [ForgeAction(InputType: typeof(SubroutineInput))]
+    public class SubroutineAction : BaseAction
+    {
+        /// <summary>
+        /// The tree walker parameters of the parent tree walker session.
+        /// Used to call InitializeSubroutineTree to get the initialized TreeWalkerSession for this Subroutine.
+        /// </summary>
+        private TreeWalkerParameters parameters { get; set; }
+
+        /// <summary>
+        /// Instantiates a SubroutineAction with the required parameters.
+        /// </summary>
+        /// <param name="parameters">The tree walker parameters of the parent tree walker session.</param>
+        public SubroutineAction(TreeWalkerParameters parameters)
+        {
+            this.parameters = parameters;
+        }
+
+        /// <summary>
+        /// The RunAction method is called when Forge encounters an ActionName while walking the tree.
+        /// </summary>
+        /// <param name="actionContext">The action context holding relevant information for this Action.</param>
+        public override async Task<ActionResponse> RunAction(ActionContext actionContext)
+        {
+            SubroutineInput input = (SubroutineInput)actionContext.ActionInput;
+
+            // Rehydrate the subroutine's SessionId if previously persisted.
+            SubroutineIntermediates intermediates = await actionContext.GetIntermediates<SubroutineIntermediates>();
+            if (intermediates == null)
+            {
+                intermediates = new SubroutineIntermediates()
+                {
+                    SessionId = Guid.NewGuid()
+                };
+
+                await actionContext.CommitIntermediates<SubroutineIntermediates>(intermediates);
+            }
+
+            // Initialize TreeWalkerSession for this subroutine.
+            TreeWalkerSession subroutineSession = this.parameters.InitializeSubroutineTree(input, intermediates.SessionId, this.parameters);
+
+            // Update KeyPrefix of ForgeState for state persistence separation.
+            subroutineSession.Parameters.ForgeState.UpdateKeyPrefix(subroutineSession.Parameters.RootSessionId, subroutineSession.Parameters.SessionId);
+
+            // Walk tree starting at CurrentTreeNode if persisted, otherwise RootTreeNodeKey if given, otherwise "Root" as default.
+            string currentTreeNode = await subroutineSession.GetCurrentTreeNode() ?? subroutineSession.Schema.RootTreeNodeKey;
+
+            // WalkTree may throw exceptions. We let this happen to allow for possible retry handling.
+            await subroutineSession.WalkTree(currentTreeNode);
+
+            // Return the subroutine's last action response if available, otherwise return tree walker Status.
+            return await subroutineSession.GetLastActionResponseAsync() ?? new ActionResponse() { Status = subroutineSession.Status };
+        }
+    }
+
+    /// <summary>
+    /// The Subroutine intermediates object that gets persisted with the Subroutine's SessionId.
+    /// </summary>
+    public class SubroutineIntermediates
+    {
+        /// <summary>
+        /// The SessionId of this Subroutine tree walker session.
+        /// </summary>
+        public Guid SessionId { get; set; }
+    }
+
+    /// <summary>
+    /// The Subroutine input object that gets instantiated from the schema.
+    /// </summary>
+    public class SubroutineInput
+    {
+        /// <summary>
+        /// The TreeName mapping to a known ForgeTree in the App.
+        /// </summary>
+        public string TreeName { get; set; }
+
+        /// <summary>
+        /// (Optional) The dynamic TreeInput object for this tree walking session.
+        /// TreeInput is able to be referenced when evaluating schema expressions.
+        /// </summary>
+        public object TreeInput { get; set; }
+
+        /// <summary>
+        /// (Optional) The path where the schema file resides.
+        /// </summary>
+        public string TreeFilePath { get; set; }
+    }
+}

--- a/Forge.TreeWalker/src/SubroutineAction.cs
+++ b/Forge.TreeWalker/src/SubroutineAction.cs
@@ -38,7 +38,7 @@ namespace Forge.TreeWalker
         /// <param name="parameters">The tree walker parameters of the parent tree walker session.</param>
         public SubroutineAction(TreeWalkerParameters parameters)
         {
-            this.parameters = parameters;
+            this.parameters = parameters ?? throw new ArgumentNullException(nameof(parameters));
         }
 
         /// <summary>

--- a/Forge.TreeWalker/src/TreeWalkerParameters.cs
+++ b/Forge.TreeWalker/src/TreeWalkerParameters.cs
@@ -81,6 +81,39 @@ namespace Forge.TreeWalker
         /// </summary>
         public Dictionary<string, Func<string, CancellationToken, Task<object>>> ExternalExecutors { get; set; }
 
+        /// <summary>
+        /// The delegate called by Forge when executing SubroutineActions to get an initialized TreeWalkerSession that Forge will call WalkTree upon.
+        /// The TreeWalkerSession should be set up according to the input to execute the Subroutine session.
+        /// Typically this delegate is expected to:
+        ///   1. Create new TreeWalkerParameters with passed in TreeName and TreeInput.
+        ///   2. Update the JsonSchema that maps from the passed in TreeName.
+        ///   3. Create a new ForgeState object. It is important for Subroutine sessions to have their own ForgeState object since the private keyPrefix gets updated.
+        ///   4. Use the same RootSessionId.
+        ///   5. Other parameters can stay the same or be changed. For example, the App could use a different UserContext or ForgeActionsAssembly for different ForgeTrees if they desire.
+        /// </summary>
+        public Func<SubroutineInput, Guid, TreeWalkerParameters, TreeWalkerSession> InitializeSubroutineTree { get; set; }
+
+        /// <summary>
+        /// The unique identifier of the root/parent session that gets passed on to Subroutine sessions.
+        /// RootSessionId will get set to SessionId if not initialized.
+        /// </summary>
+        public Guid RootSessionId { get; set; }
+
+        /// <summary>
+        /// The name of the ForgeTree in the JsonSchema.
+        /// For Subroutines, this is evaluated from the SubroutineInput on the schema.
+        /// "RootTree" will be used as TreeName if not specified.
+        /// </summary>
+        public string TreeName { get; set; }
+
+        /// <summary>
+        /// The dynamic TreeInput object for this tree walking session.
+        /// This is passed in to the root/parent session by the App.
+        /// For Subroutines, this is evaluated from the SubroutineInput on the schema.
+        /// TreeInput is able to be referenced when evaluating schema expressions.
+        /// </summary>
+        public object TreeInput { get; set; }
+
         #endregion
 
         /// <summary>

--- a/Forge.TreeWalker/src/TreeWalkerSession.cs
+++ b/Forge.TreeWalker/src/TreeWalkerSession.cs
@@ -303,9 +303,9 @@ namespace Forge.TreeWalker
                         current,
                         await this.EvaluateDynamicProperty(this.Schema.Tree[current].Properties, null),
                         this.Parameters.UserContext,
-                        this.walkTreeCts.Token,
                         this.Parameters.TreeName,
-                        this.Parameters.RootSessionId).ConfigureAwait(false);
+                        this.Parameters.RootSessionId,
+                        this.walkTreeCts.Token).ConfigureAwait(false);
 
                     try
                     {
@@ -320,9 +320,9 @@ namespace Forge.TreeWalker
                             current,
                             await this.EvaluateDynamicProperty(this.Schema.Tree[current].Properties, null),
                             this.Parameters.UserContext,
-                            this.walkTreeCts.Token,
                             this.Parameters.TreeName,
-                            this.Parameters.RootSessionId).ConfigureAwait(false);
+                            this.Parameters.RootSessionId,
+                            this.walkTreeCts.Token).ConfigureAwait(false);
                     }
 
                     current = next;

--- a/Forge.TreeWalker/src/TreeWalkerSession.cs
+++ b/Forge.TreeWalker/src/TreeWalkerSession.cs
@@ -56,6 +56,7 @@ namespace Forge.TreeWalker
 
         /// <summary>
         /// The TreeInput suffix appended to the end of the key in forgeState that maps to this tree walking session's TreeInput object.
+        /// Key: <SessionId>_TI
         /// </summary>
         public static string TreeInputSuffix = "TI";
 
@@ -63,6 +64,7 @@ namespace Forge.TreeWalker
         /// The PreviousActionResponse suffix appended to the end of the key in forgeState that maps to a previously persisted ActionResponse.
         /// When a TreeNodeKey in a tree walking session was previously successfully visited, the ActionResponses get wiped and persisted to PreviousActionResponse.
         /// GetPreviousActionResponse method is available in ActionContext.
+        /// Key: <SessionId>_<TreeActionKey>_PAR
         /// </summary>
         public static string PreviousActionResponseSuffix = "_PAR";
 
@@ -73,6 +75,11 @@ namespace Forge.TreeWalker
         /// This Action is intended to give schema authors the ability to cleanly end a tree walking path with a summary.
         /// </summary>
         public static string LeafNodeSummaryAction = "LeafNodeSummaryAction";
+
+        /// <summary>
+        /// The default TreeName if not specified in the TreeWalkerParameters.
+        /// </summary>
+        public static string DefaultTreeName = "RootTree";
 
         /// <summary>
         /// The Roslyn regex expression. Used to check if dynamic schema values should be evaluated with Roslyn.
@@ -141,7 +148,7 @@ namespace Forge.TreeWalker
 
             if (string.IsNullOrWhiteSpace(parameters.TreeName))
             {
-                this.Parameters.TreeName = "RootTree";
+                this.Parameters.TreeName = DefaultTreeName;
             }
 
             // Initialize properties from required TreeWalkerParameters properties.
@@ -509,7 +516,7 @@ namespace Forge.TreeWalker
             // Perform pre-checks.
             if (treeNode.Actions == null)
             {
-                throw new ArgumentException("Subroutine TreeNodeTypes must contain at least one SubroutineAction. TreeNodeKey: " + treeNodeKey);
+                throw new ArgumentException("Subroutine TreeNodeType does not contain any Actions. TreeNodeKey: " + treeNodeKey);
             }
 
             bool preCheck_ContainsAtLeastOneSubroutineAction = false;


### PR DESCRIPTION
Features:
1.	Subroutines
    - Subroutine support has been added. This native Forge Action walks a separate tree session and returns the last ActionResponse of that session.
    - ForgeTree
        - RootTreeNodeKey - property added. This specifies the TreeNodeKey that this ForgeTree should visit first, or "Root" by default.
        - Subroutine - TreeNodeType enum added. This node type must contain at least one SubroutineAction. Parallel SubroutineActions and regular Actions are supported.
    - SubroutineInput
        - TreeName - maps to a known ForgeTree in the App.
        - TreeInput - is a dynamic object that can be referenced from the schema.
    - InitializeSubroutineTree
        - This new Func is called in the SubroutineAction by Forge to get an initialized TreeWalkerSession from the App.
        - This gives fine-grain control to the App over the subroutine session that gets walked.
        - App is expected to initialize with a jsonSchema matching the TreeName, among other things.
        - App could choose to change any of the parameters, such as UserContext or ForgeActionsAssembly for different ForgeTrees if they desire.
2.	State Persistence and State Separation
    - Persisted state in Subroutine sessions are completely separate from the root session.
    - This means you cannot GetOutput from a node outside your session, for example.
    - State separation is accomplished by introducing RootSessionId. RootSessionId is kept the same across root and subroutine sessions.
    - IForgeDictionary.UpdateKeyPrefix method added that takes in both RootSessionId and SessionId to create a unique key per session. <RootSessionId>_<SessionId>_
    - Subroutine's SessionId is created and persisted by Forge in the SubroutineAction.
    - RootSessionId and TreeName are now passed along in ActionContext and ITreeWalkerCallbacks.
    - TreeName + TreeNodeKey can be used to uniquely identify a TreeNode at the global level. (Used in override debug APIs for example)
    - TreeName + TreeNodeKey + SessionId can be used to uniquely identify records at the session level. (Used in rate limiting for example)
3.	Cycles
    - Support for cycles (or revisiting a node) has been added. Code change for this is mostly in CommitCurrentTreeNode.
    - When revisiting a node, Forge will nullify the ActionResponses and Intermediates.
    - PreviousActionResponse persisted state has been added, and is set at the same time.
    - GetPreviousActionResponse() method added to ActionContext to allow actions access to that state.
4.	Misc
    - ForgeSchemaValidationTests added to validate the schemas used in UnitTests.
    - ForgeSchemaValidationRules.json updated with Subroutine support. Currently the SubroutineTypeNodeDefinition incorrectly allows a Subroutine type node to not include a SubroutineAction. I will fix this later.
    - EvaluateDynamicProperty now supports IDictionary types! It now also supports object types.