### PR TITLE
Updating TreeInput to work with any type.

### DIFF
--- a/Forge.TreeWalker.UnitTests/Forge.TreeWalker.UnitTests.csproj
+++ b/Forge.TreeWalker.UnitTests/Forge.TreeWalker.UnitTests.csproj
@@ -49,7 +49,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.11" />
     <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.2.0" >
+    <PackageReference Include="System.Reflection.Metadata" Version="1.2.0">
       <NoWarn>NU1605</NoWarn>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
@@ -60,13 +60,10 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="test\ExecutorUnitTests.cs" />
-    <Compile Include="test\ExternalTestType.cs" />
-    <Compile Include="test\ForgeSchemaHelper.cs" />
-    <Compile Include="test\ForgeSchemaValidationTests.cs" />
-    <Compile Include="test\TreeWalkerUnitTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="test\ActionsAndCallbacks\BaseCommonAction.cs" />
     <Compile Include="test\ActionsAndCallbacks\CollectDiagnosticsAction.cs" />
+    <Compile Include="test\ActionsAndCallbacks\ForgeUserContext.cs" />
     <Compile Include="test\ActionsAndCallbacks\ReturnSessionIdAction.cs" />
     <Compile Include="test\ActionsAndCallbacks\RevisitAction.cs" />
     <Compile Include="test\ActionsAndCallbacks\TardigradeAction.cs" />
@@ -75,7 +72,11 @@
     <Compile Include="test\ActionsAndCallbacks\TestEvaluateInputType_FailOnNonEmptyCtor_Action.cs" />
     <Compile Include="test\ActionsAndCallbacks\TestEvaluateInputTypeAction.cs" />
     <Compile Include="test\ActionsAndCallbacks\TreeWalkerCallbacks.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="test\ExecutorUnitTests.cs" />
+    <Compile Include="test\ExternalTestType.cs" />
+    <Compile Include="test\ForgeSchemaHelper.cs" />
+    <Compile Include="test\ForgeSchemaValidationTests.cs" />
+    <Compile Include="test\TreeWalkerUnitTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/Forge.TreeWalker.UnitTests/test/ActionsAndCallbacks/ForgeUserContext.cs
+++ b/Forge.TreeWalker.UnitTests/test/ActionsAndCallbacks/ForgeUserContext.cs
@@ -1,0 +1,77 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ForgeUserContext.cs" company="Microsoft">
+//     Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+// <summary>
+//     The ForgeUserContext class is passed in to TreeWalkerParameters to be used in the schema and ForgeActions as the UserContext object.
+// </summary>
+//-----------------------------------------------------------------------
+
+namespace Microsoft.Forge.TreeWalker.UnitTests
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    public class ForgeUserContext
+    {
+        public string Name { get; set; } = "MyName";
+        public string ResourceType { get; set; } = "Container";
+        public FooActionInput CustomObject { get; set; } = new FooActionInput()
+            {
+                Command = "TheCommand",
+                NestedObject = new FooActionObject()
+                {
+                    IntPropertyInObject = 10
+                },
+                ObjectArray = new FooActionObject[]
+                {
+                    new FooActionObject()
+                    {
+                        Name = "MyName"
+                    }
+                }
+            };
+
+        public int GetCount()
+        {
+            return 1;
+        }
+
+        public Task<int> GetCountAsync()
+        {
+            return Task.FromResult(2);
+        }
+
+        public IDictionary<string, string> GetDictionary()
+        {
+            return new Dictionary<string, string>()
+            {
+                {
+                    "Key1", "Value1"
+                },
+                {
+                    "Key2", "Value2"
+                }
+            };
+        }
+
+        public IDictionary<string, FooActionInput> GetCustomObjectDictionary()
+        {
+            return new Dictionary<string, FooActionInput>()
+            {
+                {
+                    "Key1", this.CustomObject
+                }
+            };
+        }
+
+        public FooActionInput[] GetCustomObjectArray()
+        {
+            return new FooActionInput[]
+            {
+                this.CustomObject,
+                this.CustomObject
+            };
+        }
+    }
+}

--- a/Forge.TreeWalker.UnitTests/test/ActionsAndCallbacks/TestEvaluateInputTypeAction.cs
+++ b/Forge.TreeWalker.UnitTests/test/ActionsAndCallbacks/TestEvaluateInputTypeAction.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Forge.TreeWalker.UnitTests
         public Func<bool> BoolDelegate { get; set; }
         public Func<Task<bool>> BoolDelegateAsync { get; set; }
         public Dictionary<string, string> StringDictionary { get; set; }
+        public Dictionary<string, FooActionObject> ObjectDictionary { get; set; }
         public object DynamicObject { get; set; }
     }
 

--- a/Forge.TreeWalker.UnitTests/test/ExampleSchemas/TestEvaluateInputTypeSchema.json
+++ b/Forge.TreeWalker.UnitTests/test/ExampleSchemas/TestEvaluateInputTypeSchema.json
@@ -39,6 +39,13 @@
                             "TestKey1": "C#|UserContext.Name",
                             "TestKey2": "TestValue2"
                         },
+                        "ObjectDictionary": {
+                            "TestKey1": {
+                                "Name": "C#|UserContext.Name",
+                                "Value": "MyValue"
+                            },
+                            "TestKey2": "C#|UserContext.CustomObject.NestedObject"
+                        },
                         "DynamicObject": {
                             "DynamicPropertyString": "TestValue1",
                             "DynamicPropertyInt": 10,


### PR DESCRIPTION
TreeInput was only working with String types. Fixed a few issues in EvaluateDynamicProperty method so that TreeInput (as well as any other property) will work with any type. Added many tests to ensure TreeInput works with object, dictionary, array, nested objects, nested roslyn expressions, etc..

Fixes/Updates:
* Roslyn expressions now evaluate to System.Object by default instead of System.String when no knownType is given. This was causing issues for null knownType properties that were not of type String.
* EvaluateDynamicProperty updated to treat object knownType similarly to null knownType. The method will only use the knownType if it is not null and not object. This fixes a few holes in JObject and JArray cases.
* The old KnownType mechanism in RoslynRegex now accepts any string instead of just a single word. This allows users to do something like: C#<Collections.Generic.IDictionary`2[System.String,System.String]>|