### PR TITLE
Adding Enum support

### DIFF
--- a/Forge.TreeWalker.UnitTests/test/ActionsAndCallbacks/ForgeUserContext.cs
+++ b/Forge.TreeWalker.UnitTests/test/ActionsAndCallbacks/ForgeUserContext.cs
@@ -29,6 +29,12 @@ namespace Microsoft.Forge.TreeWalker.UnitTests
                     {
                         Name = "MyName"
                     }
+                },
+                FooEnumArray = new FooEnum[]
+                {
+                    FooEnum.TestEnumOne,
+                    FooEnum.TestEnumTwo,
+                    (FooEnum)1
                 }
             };
 

--- a/Forge.TreeWalker.UnitTests/test/ActionsAndCallbacks/TestEvaluateInputTypeAction.cs
+++ b/Forge.TreeWalker.UnitTests/test/ActionsAndCallbacks/TestEvaluateInputTypeAction.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Forge.TreeWalker.UnitTests
         public Dictionary<string, string> StringDictionary { get; set; }
         public Dictionary<string, FooActionObject> ObjectDictionary { get; set; }
         public object DynamicObject { get; set; }
+        public FooEnum[] FooEnumArray { get; set; }
     }
 
     public class FooActionObject
@@ -61,5 +62,12 @@ namespace Microsoft.Forge.TreeWalker.UnitTests
         public string Name { get; set; }
         public string Value { get; set; }
         public int IntPropertyInObject { get; set; }
+    }
+
+    public enum FooEnum
+    {
+        TestEnumOne = 0,
+
+        TestEnumTwo = 1
     }
 }

--- a/Forge.TreeWalker.UnitTests/test/ExampleSchemas/TestEvaluateInputTypeSchema.json
+++ b/Forge.TreeWalker.UnitTests/test/ExampleSchemas/TestEvaluateInputTypeSchema.json
@@ -53,7 +53,19 @@
                             "DynamicPropertyNestedObject": {
                                 "NestedPropertyOne": "NestedValue1"
                             }
-                        }
+                        },
+                        "FooEnumArray": [
+                            "TestEnumTwo",
+                            "1",
+                            1,
+                            "C#|\"TestEnumTwo\"",
+                            "C#|\"1\"",
+                            "C#|1",
+                            "100",
+                            100,
+                            "C#|FooEnum.TestEnumTwo",
+                            "C#|(FooEnum)Enum.Parse(typeof(FooEnum), \"TestEnumOne\")"
+                        ]
                     }
                 }
             }

--- a/Forge.TreeWalker.UnitTests/test/ForgeSchemaHelper.cs
+++ b/Forge.TreeWalker.UnitTests/test/ForgeSchemaHelper.cs
@@ -260,6 +260,27 @@ namespace Microsoft.Forge.TreeWalker.UnitTests
             }
         ";
 
+        public const string TestEvaluateInputTypeAction_UndefinedEnumMemberFail = @"
+            {
+                ""Tree"": {
+                    ""Root"": {
+                        ""Type"": ""Action"",
+                        ""Actions"": {
+                            ""Root_TestEvaluateInputTypeAction"": {
+                                ""Action"": ""TestEvaluateInputTypeAction"",
+                                ""Input"": {
+                                    ""FooEnumArray"": [
+                                        ""UNDEFINED_Enum_Value""
+                                    ]
+                                },
+                                ""ContinuationOnRetryExhaustion"": true
+                            }
+                        }
+                    }
+                }
+            }
+        ";
+
         public const string LeafNodeSummaryAction = @"
             {
                 ""Tree"": {

--- a/Forge.TreeWalker/src/ExpressionExecutor.cs
+++ b/Forge.TreeWalker/src/ExpressionExecutor.cs
@@ -110,7 +110,10 @@ namespace Microsoft.Forge.TreeWalker
                              this.scriptOptions,
                              typeof(CodeGenInputParams)));
 
-            return (T)(await script.RunAsync(this.parameters).ConfigureAwait(false)).ReturnValue;
+            // Execute script and return the result.
+            // Parse Enum types explicitly since they cannot be casted directly.
+            var temp = (await script.RunAsync(this.parameters).ConfigureAwait(false)).ReturnValue;
+            return typeof(T).IsEnum ? (T)Enum.Parse(typeof(T), temp.ToString()) : (T)temp;
         }
 
         /// <summary>

--- a/Forge.TreeWalker/src/TreeWalkerSession.cs
+++ b/Forge.TreeWalker/src/TreeWalkerSession.cs
@@ -923,6 +923,12 @@ namespace Microsoft.Forge.TreeWalker
                         }
                     }
 
+                    if (knownType?.IsEnum ?? false)
+                    {
+                        // Case when schema property is an Enum type.
+                        return Enum.Parse(knownType, schemaObj);
+                    }
+
                     return schemaObj;
                 }
                 else if (schemaObj is JObject)
@@ -978,8 +984,20 @@ namespace Microsoft.Forge.TreeWalker
                 else
                 {
                     // Case when schema object is a value type.
+                    // Return the value as an Enum if knownType is an Enum.
                     // Return the value as the knownType if given.
-                    return knownType != null ? Convert.ChangeType(schemaObj, knownType) : schemaObj;
+                    if (knownType == null)
+                    {
+                        return schemaObj;
+                    }
+                    else if (knownType.IsEnum)
+                    {
+                        return Enum.Parse(knownType, schemaObj.ToString());
+                    }
+                    else
+                    {
+                        return Convert.ChangeType(schemaObj, knownType);
+                    }
                 }
             }
             catch (OperationCanceledException)


### PR DESCRIPTION
While evaluating tree properties, Forge is now able to parse integer and string types into Enum members.

This required 3 small changes across EvaluateDynamicProperty and ExpressionExecutor.

Example of what Forge can now parse:
```json
"FooEnumArray": [
    "TestEnumTwo",
    "1",
    1,
    "C#|\"TestEnumTwo\"",
    "C#|\"1\"",
    "C#|1",
    "100",
    100,
    "C#|FooEnum.TestEnumTwo",
    "C#|(FooEnum)Enum.Parse(typeof(FooEnum), \"TestEnumOne\")"
]
```
```cs
    public enum FooEnum
    {
        TestEnumOne = 0,
        TestEnumTwo = 1
    }
```
Note that Forge will hit exceptions while parsing Enums if the value is: null, string.Empty, or a string that doesn't match a defined Enum member (e.g. "TestEnumOneHundred").

Note that integer (and integer as string) values that do not map to a defined Enum member are allowed. E.g. 100. This is because it is allowed in .Net and does not throw an exception. E.g. Console.WriteLine((FooEnum)100);.
