### PR TITLE
Major Roslyn Improvements to Memory and Running Time

### DIFF
--- a/Forge.TreeWalker.UnitTests/test/ExampleSchemas/TardigradeSchema.json
+++ b/Forge.TreeWalker.UnitTests/test/ExampleSchemas/TardigradeSchema.json
@@ -43,7 +43,7 @@
             "ChildSelector": [
                 {
                     "Label": "Tardigrade_Success",
-                    "ShouldSelect": "C#|Session.GetLastActionResponse().Status == \"Success\"",
+                    "ShouldSelect": "C#|(await Session.GetLastActionResponseAsync()).Status == \"Success\"",
                     "Child": "Tardigrade_Success"
                 },
                 {

--- a/Forge.TreeWalker/src/ExpressionExecutor.cs
+++ b/Forge.TreeWalker/src/ExpressionExecutor.cs
@@ -26,7 +26,9 @@ namespace Microsoft.Forge.TreeWalker
     {
         /// <summary>
         /// Code that Forge uses to prime the parentScript on initialization.
-        /// Evaluating some code moves roughly 600ms from the first expression to initializing the parentScript.
+        /// Evaluating any random code moves roughly 600ms from the first expression to initializing the parentScript.
+        /// The first expression still takes roughly 100ms when tested.
+        /// The code block is arbitrary, though I did find in testing that the first expression ran quicker when the logic was similar to the parentScriptCode.
         /// </summary>
         public static string ParentScriptCode = "(1+1).ToString()";
 
@@ -51,8 +53,9 @@ namespace Microsoft.Forge.TreeWalker
         private List<Type> dependencies;
 
         /// <summary>
-        /// The ScriptCache is used to cache and re-use Roslyn scripts.
-        /// Scripts include the parentScript, as well as all unique expressions that get Executed.
+        /// The ScriptCache holds Roslyn Scripts that are created using parentScript.ContinueWith.
+        /// This saves on memory and time since these continued Scripts use the already compiled parentScript as a base.
+        /// The parentScript gets asynchronously compiled, ran, and cached on initialization.
         /// </summary>
         private ConcurrentDictionary<string, Script<object>> scriptCache;
 

--- a/Forge.TreeWalker/src/ExpressionExecutor.cs
+++ b/Forge.TreeWalker/src/ExpressionExecutor.cs
@@ -12,8 +12,10 @@ namespace Microsoft.Forge.TreeWalker
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
+    using System.Collections.Immutable;
     using System.Reflection;
     using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp.Scripting;
     using Microsoft.CodeAnalysis.Scripting;
 
@@ -23,19 +25,36 @@ namespace Microsoft.Forge.TreeWalker
     public class ExpressionExecutor
     {
         /// <summary>
+        /// Code that Forge uses to prime the parentScript on initialization.
+        /// Evaluating some code moves roughly 600ms from the first expression to initializing the parentScript.
+        /// </summary>
+        public static string ParentScriptCode = "(1+1).ToString()";
+
+        /// <summary>
+        /// The parentScriptTask kicks off initializing the Roslyn parentScript asynchronously, allowing ExpressionExecutor to construct very quickly.
+        /// Initializing the Roslyn parentScript takes about 2 seconds. This time is saved if the application takes time to initialize before the first WalkTree call.
+        /// </summary>
+        public Task parentScriptTask { get; private set; }
+
+        /// <summary>
+        /// The parentScript that, upon initialization, gets Created, RunAsync, and added to the ScriptCache.
+        /// All expressions that get Executed are continued from the parentScript, avoiding additional compiles.
+        /// 
+        /// Before improvement - each unique expression would cost 25MB, take 2 seconds on first execution, then 0ms on further executions.
+        /// After improvement - only the parentScript costs 25MB and takes 2 seconds. Each unique expression costs < 0.5MB, takes 15ms on first execution, then 0ms on further executions.
+        /// </summary>
+        private Script<object> parentScript;
+
+        /// <summary>
         /// List of external type dependencies needed to compile expressions.
         /// </summary>
         private List<Type> dependencies;
 
         /// <summary>
-        /// Script cache used to cache and re-use compiled Roslyn scripts.
+        /// The ScriptCache is used to cache and re-use Roslyn scripts.
+        /// Scripts include the parentScript, as well as all unique expressions that get Executed.
         /// </summary>
         private ConcurrentDictionary<string, Script<object>> scriptCache;
-
-        /// <summary>
-        /// Roslyn script options.
-        /// </summary>
-        private ScriptOptions scriptOptions;
 
         /// <summary>
         /// Global parameters passed to Roslyn scripts that can be referenced inside expressions.
@@ -59,6 +78,7 @@ namespace Microsoft.Forge.TreeWalker
                 Session = session,
                 TreeInput = treeInput
             };
+
             this.scriptCache = scriptCache ?? new ConcurrentDictionary<string, Script<object>>();
             this.Initialize();
         }
@@ -103,17 +123,16 @@ namespace Microsoft.Forge.TreeWalker
         /// <returns>The T value of the evaluated code.</returns>
         public async Task<T> Execute<T>(string expression)
         {
-            var script = this.scriptCache.GetOrAdd(
+            await this.parentScriptTask;
+
+            Script<object> expressionScript = this.scriptCache.GetOrAdd(
                 expression,
-                (key) => CSharpScript.Create<object>(
-                             string.Format("return {0};", expression),
-                             this.scriptOptions,
-                             typeof(CodeGenInputParams)));
+                (key) => this.parentScript.ContinueWith(string.Format("return {0};", expression)));
 
             // Execute script and return the result.
             // Parse Enum types explicitly since they cannot be casted directly.
-            var temp = (await script.RunAsync(this.parameters).ConfigureAwait(false)).ReturnValue;
-            return typeof(T).IsEnum ? (T)Enum.Parse(typeof(T), temp.ToString()) : (T)temp;
+            object result = (await expressionScript.RunAsync(this.parameters).ConfigureAwait(false)).ReturnValue;
+            return typeof(T).IsEnum ? (T)Enum.Parse(typeof(T), result.ToString()) : (T)result;
         }
 
         /// <summary>
@@ -121,35 +140,54 @@ namespace Microsoft.Forge.TreeWalker
         /// </summary>
         private void Initialize()
         {
-            this.scriptOptions = ScriptOptions.Default;
-
-            // Add references to required assemblies.
-            Assembly mscorlib = typeof(object).Assembly;
-            Assembly cSharpAssembly = typeof(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo).Assembly;
-            this.scriptOptions = this.scriptOptions.AddReferences(mscorlib, cSharpAssembly);
-
-            // Add required namespaces.
-            this.scriptOptions = this.scriptOptions.AddImports("System");
-            this.scriptOptions = this.scriptOptions.AddImports("System.Threading.Tasks");
-
-            string systemCoreAssemblyName = mscorlib.GetName().Name;
-
-            // Add external dependencies.
-            if (this.dependencies != null)
+            if (this.scriptCache.TryGetValue(ParentScriptCode, out this.parentScript))
             {
-                foreach (Type type in this.dependencies)
-                {
-                    string fullAssemblyName = type.Assembly.GetName().Name;
-
-                    // While adding the reference again is okay, we can not AddImports for systemCoreAssembly.
-                    if (fullAssemblyName == systemCoreAssemblyName)
-                    {
-                        continue;
-                    }
-
-                    this.scriptOptions = this.scriptOptions.AddReferences(type.Assembly).AddImports(type.Namespace);
-                }
+                // The parentScript is already initialized.
+                this.parentScriptTask = Task.CompletedTask;
+                return;
             }
+
+            this.parentScriptTask = Task.Run(async () =>
+            {
+                ScriptOptions scriptOptions = ScriptOptions.Default.WithMetadataResolver(new MissingResolver());
+
+                // Add references to required assemblies.
+                Assembly mscorlib = typeof(object).Assembly;
+                Assembly systemCore = typeof(System.Linq.Enumerable).Assembly;
+                Assembly cSharpAssembly = typeof(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo).Assembly;
+                scriptOptions = scriptOptions.AddReferences(mscorlib, systemCore, cSharpAssembly);
+
+                // Add required namespaces.
+                scriptOptions = scriptOptions.AddImports(
+                    "System",
+                    "System.Threading.Tasks");
+
+                string systemCoreAssemblyName = mscorlib.GetName().Name;
+
+                // Add external dependencies.
+                if (this.dependencies != null)
+                {
+                    foreach (Type type in this.dependencies)
+                    {
+                        string fullAssemblyName = type.Assembly.GetName().Name;
+
+                        // While adding the reference again is okay, we can not AddImports for systemCoreAssembly.
+                        if (fullAssemblyName == systemCoreAssemblyName)
+                        {
+                            continue;
+                        }
+
+                        scriptOptions = scriptOptions.AddReferences(type.Assembly).AddImports(type.Namespace);
+                    }
+                }
+
+                // Create the parentScript and add it to scriptCache. Execute the parentScript so Roslyn is primed to evaluate further expressions.
+                this.parentScript = this.scriptCache.GetOrAdd(
+                    ParentScriptCode,
+                    (key) => CSharpScript.Create<object>(ParentScriptCode, scriptOptions, typeof(CodeGenInputParams)));
+
+                await this.parentScript.RunAsync(this.parameters).ConfigureAwait(false);
+            });
         }
 
         /// <summary>
@@ -163,8 +201,10 @@ namespace Microsoft.Forge.TreeWalker
         }
 
         /// <summary>
-        /// This class defines the global parameter that will be
-        /// passed into the Roslyn expression evaluator.
+        /// This class defines the global parameter that will be passed into the Roslyn expression evaluator.
+        /// 
+        /// TODO: When Creating a Roslyn Script, the entire Assembly that the passed in GlobalsType resides in gets loaded.
+        ///       An optimization would be to move this CodeGenInputParams to its own project/assembly.
         /// </summary>
         public class CodeGenInputParams
         {
@@ -184,6 +224,31 @@ namespace Microsoft.Forge.TreeWalker
             /// For Subroutines, this is evaluated from the SubroutineInput on the schema.
             /// </summary>
             public dynamic TreeInput { get; set; }
+        }
+
+        /// <summary>
+        /// The MissingResolve class is used to reduce the memory consumption of Roslyn.
+        /// This is accomplished by not loading missing references.
+        /// The end result is that Creating/Compiling a Script takes 25MB instead of 75MB.
+        /// </summary>
+        private class MissingResolver : Microsoft.CodeAnalysis.MetadataReferenceResolver
+        {
+            public override bool Equals(object other)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override int GetHashCode()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override bool ResolveMissingAssemblies => false;
+
+            public override ImmutableArray<PortableExecutableReference> ResolveReference(string reference, string baseFilePath, MetadataReferenceProperties properties)
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }

--- a/Forge.TreeWalker/src/TreeWalkerParameters.cs
+++ b/Forge.TreeWalker/src/TreeWalkerParameters.cs
@@ -33,12 +33,14 @@ namespace Microsoft.Forge.TreeWalker
         /// <summary>
         /// The string representation of the JSON schema.
         /// Note: Either ForgeTree or JsonSchema must be used to construct a TreeWalkerParameters. The other property should be null.
+        ///       Recommended to cache the deserialized ForgeTree in your app and use that to avoid Forge deserializing the JsonSchema each initialize.
         /// </summary>
         public string JsonSchema { get; private set; }
 
         /// <summary>
         /// The ForgeTree for this session.
         /// Note: Either ForgeTree or JsonSchema must be used to construct a TreeWalkerParameters. The other property should be null.
+        ///       Recommended to cache the deserialized ForgeTree in your app and use that to avoid Forge deserializing the JsonSchema each initialize.
         /// </summary>
         public ForgeTree ForgeTree { get; set; }
 
@@ -126,34 +128,7 @@ namespace Microsoft.Forge.TreeWalker
 
         /// <summary>
         /// Instantiates a TreeWalkerParameters object with the properties that are required to instantiate a TreeWalkerSession object.
-        /// </summary>
-        /// <param name="sessionId">The unique identifier for this session.</param>
-        /// <param name="jsonSchema">The JSON schema.</param>
-        /// <param name="forgeState">The Forge state.</param>
-        /// <param name="callbacks">The callbacks object.</param>
-        /// <param name="token">The cancellation token.</param>
-        public TreeWalkerParameters(
-            Guid sessionId,
-            string jsonSchema,
-            IForgeDictionary forgeState,
-            ITreeWalkerCallbacks callbacks,
-            CancellationToken token)
-        {
-            if (sessionId == Guid.Empty) throw new ArgumentNullException("sessionId");
-            if (string.IsNullOrWhiteSpace(jsonSchema)) throw new ArgumentNullException("jsonSchema");
-            if (forgeState == null) throw new ArgumentNullException("forgeState");
-            if (callbacks == null) throw new ArgumentNullException("callbacks");
-            if (token == null) throw new ArgumentNullException("token");
-
-            this.SessionId = sessionId;
-            this.JsonSchema = jsonSchema;
-            this.ForgeState = forgeState;
-            this.Callbacks = callbacks;
-            this.Token = token;
-        }
-
-        /// <summary>
-        /// Instantiates a TreeWalkerParameters object with the properties that are required to instantiate a TreeWalkerSession object.
+        /// Note: Recommended to cache the deserialized ForgeTree in your app and use that to avoid Forge deserializing the JsonSchema each initialize.
         /// </summary>
         /// <param name="sessionId">The unique identifier for this session.</param>
         /// <param name="forgeTree">The ForgeTree for this session.</param>
@@ -175,6 +150,35 @@ namespace Microsoft.Forge.TreeWalker
 
             this.SessionId = sessionId;
             this.ForgeTree = forgeTree;
+            this.ForgeState = forgeState;
+            this.Callbacks = callbacks;
+            this.Token = token;
+        }
+
+        /// <summary>
+        /// Instantiates a TreeWalkerParameters object with the properties that are required to instantiate a TreeWalkerSession object.
+        /// Note: Recommended to cache the deserialized ForgeTree in your app and use that to avoid Forge deserializing the JsonSchema each initialize.
+        /// </summary>
+        /// <param name="sessionId">The unique identifier for this session.</param>
+        /// <param name="jsonSchema">The JSON schema.</param>
+        /// <param name="forgeState">The Forge state.</param>
+        /// <param name="callbacks">The callbacks object.</param>
+        /// <param name="token">The cancellation token.</param>
+        public TreeWalkerParameters(
+            Guid sessionId,
+            string jsonSchema,
+            IForgeDictionary forgeState,
+            ITreeWalkerCallbacks callbacks,
+            CancellationToken token)
+        {
+            if (sessionId == Guid.Empty) throw new ArgumentNullException("sessionId");
+            if (string.IsNullOrWhiteSpace(jsonSchema)) throw new ArgumentNullException("jsonSchema");
+            if (forgeState == null) throw new ArgumentNullException("forgeState");
+            if (callbacks == null) throw new ArgumentNullException("callbacks");
+            if (token == null) throw new ArgumentNullException("token");
+
+            this.SessionId = sessionId;
+            this.JsonSchema = jsonSchema;
             this.ForgeState = forgeState;
             this.Callbacks = callbacks;
             this.Token = token;


### PR DESCRIPTION
Roslyn Improvements Summary:
- **Memory** consumption down from 75MB per unique expression to a flat 25MB plus 0.3MB~ per unique expression. This is a 250x improvement or 0.4% memory consumed.
- **Running time** of first execution down from 2 seconds for each unique expression to a flat 2 seconds plus 15ms per unique expression. This is a 133x improvement or 0.75% running time.
- All changes are under the covers. No changes required by applications using Forge.

Feature breakdown:
- ParentScript
  - The parentScript that, upon initialization, gets Created, RunAsync, and added to the ScriptCache.
  - All Executed expressions are continued from the parentScript, avoiding additional compiles.
  - Before improvement - each unique expression would cost 25MB, take 2 seconds on first execution, then 0ms on further executions.
  - After improvement - only the parentScript costs 25MB and takes 2 seconds. Each unique expression costs < 0.5MB, takes 15ms on first execution, then 0ms on further executions.

- ParentScriptTask
  - The parentScriptTask kicks off initializing the Roslyn parentScript asynchronously, allowing ExpressionExecutor to construct very quickly.
  - This initialization time is saved if the application takes time to initialize before the first WalkTree call.
  - Before improvement - 1800ms for first initialize.
  - After improvement - 2ms for first Initialize. 0ms for further initializes (new TreeWalkerSessions using same ScriptCache).

- ParentScriptCode
  - Code that Forge uses to prime the parentScript on initialization.
  - Evaluating some code moves roughly 600ms from the first expression to asynchronously initializing the parentScript.

- ScriptCache rework
  - ScriptCache now caches Scripts that come from the parentScript.ContinueWith. ScriptCache still caches one Script per unique Expression, but these no longer get compiled.
  - ScriptCache now caches the ParentScript as well on initialization.

- MetadataReferenceResolver
  - This added ScriptOption causes Roslyn to not load missing references.
  - Before improvement - it costs about 75MB to initialize, then 0.5-1.5MB per unique expression.
  - After improvement -  it costs about 25MB to initialize, then 0.05-0.5MB per unique expression.
