### PR TITLE
NetStandard workaround for MissingResolver issue plus other cleanups

### DIFF
--- a/Forge.TreeWalker.UnitTests/test/TreeWalkerUnitTests.cs
+++ b/Forge.TreeWalker.UnitTests/test/TreeWalkerUnitTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Forge.TreeWalker.UnitTests
         private TreeWalkerParameters parameters;
         private TreeWalkerSession session;
         private Dictionary<string, ForgeTree> forgeTrees = new Dictionary<string, ForgeTree>();
-        private ConcurrentDictionary<string, Script<object>> scriptCache = new ConcurrentDictionary<string, Script<object>>();
+        private readonly ConcurrentDictionary<string, Script<object>> scriptCache = new ConcurrentDictionary<string, Script<object>>();
 
 
         public void TestInitialize(string jsonSchema, string treeName = null, string currentNodeSkipActionContext = null)
@@ -728,8 +728,10 @@ namespace Microsoft.Forge.TreeWalker.UnitTests
         {
             this.TestInitialize(jsonSchema: ForgeSchemaHelper.ExternalExecutors);
 
-            Dictionary<string, Func<string, CancellationToken, Task<object>>> externalExecutors = new Dictionary<string, Func<string, CancellationToken, Task<object>>>();
-	        externalExecutors.Add("External|", External);
+            Dictionary<string, Func<string, CancellationToken, Task<object>>> externalExecutors = new Dictionary<string, Func<string, CancellationToken, Task<object>>>
+            {
+                { "External|", External }
+            };
 
             this.parameters.ExternalExecutors = externalExecutors;
             this.session = new TreeWalkerSession(this.parameters);

--- a/Forge.TreeWalker/Forge.TreeWalker.csproj
+++ b/Forge.TreeWalker/Forge.TreeWalker.csproj
@@ -14,6 +14,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageOutputPath>bin\Release</PackageOutputPath>
     <IncludeSymbols>true</IncludeSymbols>
+    <PackageTags>Forge;TreeWalker;Roslyn;async;dynamic;generic;workflow engine;decision tree;config;stateful;low-code;tree visualization;workflow framework;JSON</PackageTags>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GitVersionTask" Version="5.0.1">

--- a/Forge.TreeWalker/src/ActionContext.cs
+++ b/Forge.TreeWalker/src/ActionContext.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Forge.TreeWalker
             }
             catch
             {
-                return default(T);
+                return default;
             }
         }
 

--- a/Forge.TreeWalker/src/SubroutineAction.cs
+++ b/Forge.TreeWalker/src/SubroutineAction.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Forge.TreeWalker
         /// The tree walker parameters of the parent tree walker session.
         /// Used to call InitializeSubroutineTree to get the initialized TreeWalkerSession for this Subroutine.
         /// </summary>
-        private TreeWalkerParameters parameters { get; set; }
+        private readonly TreeWalkerParameters parameters;
 
         /// <summary>
         /// Instantiates a SubroutineAction with the required parameters.


### PR DESCRIPTION
There's a known issue with NetStandard/NetCore when overriding the MetadataReferenceResolver. I worked around this by using conditional compilation to only use the MissingResolver when the target framework is Net462.

Added PackageTags to csproj for better discoverability in NuGet.

Fixing up some random warnings.