### PR TITLE
Feature/forceparallelactions

### DIFF
--- a/Forge.TreeWalker/src/TreeWalkerSession.cs
+++ b/Forge.TreeWalker/src/TreeWalkerSession.cs
@@ -714,6 +714,9 @@ namespace Microsoft.Forge.TreeWalker
             ActionDefinition actionDefinition,
             CancellationToken token)
         {
+            // Ensure ForgeActions run in parallel by yielding back the task.
+            await Task.Yield();
+
             // Initialize values. Default infinite timeout. Default RetryPolicyType.None.
             int retryCount = 0;
             Exception innerException = null;


### PR DESCRIPTION
Ensure ForgeActions run in parallel (when part of the same TreeNode) by immediately yielding back the task in ExecuteActionWithRetry.
This prevents an issue where ForgeActions would not get kicked off in quick succession as expected, but only once the execution path in the ForgeAction performed an await. Issues were faced where ForgeActions would be running synchronously, and only kick off the "parallel action" after the first ForgeAction was fully completed.

Also fixed a flaky UT related to a race when cancelling the tree. Either a TaskCanceledException or OperationCanceledException will be thrown depending which task recognizes the cancelation token first.