### PR TITLE
feat: Add OutputBindings to TreeAction for declarative variable binding

### DIFF
--- a/Forge.TreeWalker.UnitTests/Forge.TreeWalker.UnitTests.csproj
+++ b/Forge.TreeWalker.UnitTests/Forge.TreeWalker.UnitTests.csproj
@@ -85,6 +85,9 @@
     <None Include="test\ExampleSchemas\TestEvaluateInputTypeSchema.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="test\ExampleSchemas\OutputBindingsSchema.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="test\InvalidTestSchemas\InvalidActionTestSchema.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Forge.TreeWalker.UnitTests/test/ExampleSchemas/OutputBindingsSchema.json
+++ b/Forge.TreeWalker.UnitTests/test/ExampleSchemas/OutputBindingsSchema.json
@@ -1,0 +1,74 @@
+{
+    "Tree": {
+        "Root": {
+            "Type": "Action",
+            "Actions": {
+                "Root_CollectDiagnosticsAction": {
+                    "Action": "CollectDiagnosticsAction",
+                    "Input": {
+                        "Command": "RunCollectDiagnostics.exe"
+                    },
+                    "OutputBindings": {
+                        "diagStatus": "Status",
+                        "diagStatusCode": "StatusCode",
+                        "diagOutput": "Output"
+                    }
+                }
+            },
+            "ChildSelector": [
+                {
+                    "Label": "DiagnosticsSuccess",
+                    "ShouldSelect": "C#|Vars.diagStatus == \"Success\"",
+                    "Child": "Analyze"
+                },
+                {
+                    "Label": "DiagnosticsFailure",
+                    "Child": "DiagnosticsFailure"
+                }
+            ]
+        },
+        "Analyze": {
+            "Type": "Action",
+            "Actions": {
+                "Analyze_AnalyzeAction": {
+                    "Action": "CollectDiagnosticsAction",
+                    "Input": {
+                        "Command": "C#|\"Analyze --code=\" + Vars.diagStatusCode.ToString()"
+                    },
+                    "OutputBindings": {
+                        "analyzeStatus": "Status",
+                        "analysisResult": "Output"
+                    }
+                }
+            },
+            "ChildSelector": [
+                {
+                    "Label": "AnalysisComplete",
+                    "ShouldSelect": "C#|Vars.analyzeStatus == \"Success\"",
+                    "Child": "AnalysisComplete"
+                },
+                {
+                    "Label": "AnalysisFailure",
+                    "Child": "AnalysisFailure"
+                }
+            ]
+        },
+        "AnalysisComplete": {
+            "Type": "Leaf",
+            "Actions": {
+                "AnalysisComplete_Summary": {
+                    "Action": "LeafNodeSummaryAction",
+                    "Input": {
+                        "Status": "C#|Vars.analyzeStatus"
+                    }
+                }
+            }
+        },
+        "AnalysisFailure": {
+            "Type": "Leaf"
+        },
+        "DiagnosticsFailure": {
+            "Type": "Leaf"
+        }
+    }
+}

--- a/Forge.TreeWalker.UnitTests/test/ForgeSchemaHelper.cs
+++ b/Forge.TreeWalker.UnitTests/test/ForgeSchemaHelper.cs
@@ -570,5 +570,255 @@ namespace Microsoft.Forge.TreeWalker.UnitTests
                 }
             }
         ";
+
+        #region OutputBindings Schemas
+
+        public const string OutputBindings_BasicStatus = @"
+            {
+                ""Tree"": {
+                    ""Root"": {
+                        ""Type"": ""Action"",
+                        ""Actions"": {
+                            ""Root_CollectDiagnosticsAction"": {
+                                ""Action"": ""CollectDiagnosticsAction"",
+                                ""Input"": {
+                                    ""Command"": ""RunDiagnostics""
+                                },
+                                ""OutputBindings"": {
+                                    ""diagStatus"": ""Status"",
+                                    ""diagStatusCode"": ""StatusCode""
+                                }
+                            }
+                        },
+                        ""ChildSelector"": [
+                            {
+                                ""ShouldSelect"": ""C#|Vars.diagStatus == \""Success\"""",
+                                ""Child"": ""Success""
+                            },
+                            {
+                                ""Child"": ""Failure""
+                            }
+                        ]
+                    },
+                    ""Success"": {
+                        ""Type"": ""Leaf""
+                    },
+                    ""Failure"": {
+                        ""Type"": ""Leaf""
+                    }
+                }
+            }";
+
+        public const string OutputBindings_OutputProperty = @"
+            {
+                ""Tree"": {
+                    ""Root"": {
+                        ""Type"": ""Action"",
+                        ""Actions"": {
+                            ""Root_CollectDiagnosticsAction"": {
+                                ""Action"": ""CollectDiagnosticsAction"",
+                                ""Input"": {
+                                    ""Command"": ""RunDiagnostics""
+                                },
+                                ""OutputBindings"": {
+                                    ""diagOutput"": ""Output""
+                                }
+                            }
+                        },
+                        ""ChildSelector"": [
+                            {
+                                ""ShouldSelect"": ""C#|Vars.diagOutput != null"",
+                                ""Child"": ""HasOutput""
+                            },
+                            {
+                                ""Child"": ""NoOutput""
+                            }
+                        ]
+                    },
+                    ""HasOutput"": {
+                        ""Type"": ""Leaf""
+                    },
+                    ""NoOutput"": {
+                        ""Type"": ""Leaf""
+                    }
+                }
+            }";
+
+        public const string OutputBindings_CrossNode = @"
+            {
+                ""Tree"": {
+                    ""Root"": {
+                        ""Type"": ""Action"",
+                        ""Actions"": {
+                            ""Root_CollectDiagnosticsAction"": {
+                                ""Action"": ""CollectDiagnosticsAction"",
+                                ""Input"": {
+                                    ""Command"": ""RunDiagnostics""
+                                },
+                                ""OutputBindings"": {
+                                    ""firstStatus"": ""Status""
+                                }
+                            }
+                        },
+                        ""ChildSelector"": [
+                            {
+                                ""ShouldSelect"": ""C#|Vars.firstStatus == \""Success\"""",
+                                ""Child"": ""SecondAction""
+                            }
+                        ]
+                    },
+                    ""SecondAction"": {
+                        ""Type"": ""Action"",
+                        ""Actions"": {
+                            ""SecondAction_TardigradeAction"": {
+                                ""Action"": ""TardigradeAction"",
+                                ""OutputBindings"": {
+                                    ""secondStatus"": ""Status""
+                                }
+                            }
+                        },
+                        ""ChildSelector"": [
+                            {
+                                ""ShouldSelect"": ""C#|Vars.firstStatus == \""Success\"" && Vars.secondStatus == \""Success\"""",
+                                ""Child"": ""BothSuccess""
+                            },
+                            {
+                                ""Child"": ""Failure""
+                            }
+                        ]
+                    },
+                    ""BothSuccess"": {
+                        ""Type"": ""Leaf""
+                    },
+                    ""Failure"": {
+                        ""Type"": ""Leaf""
+                    }
+                }
+            }";
+
+        public const string OutputBindings_VarOverwrite = @"
+            {
+                ""Tree"": {
+                    ""Root"": {
+                        ""Type"": ""Action"",
+                        ""Actions"": {
+                            ""Root_CollectDiagnosticsAction"": {
+                                ""Action"": ""CollectDiagnosticsAction"",
+                                ""Input"": {
+                                    ""Command"": ""RunDiagnostics""
+                                },
+                                ""OutputBindings"": {
+                                    ""status"": ""Status""
+                                }
+                            }
+                        },
+                        ""ChildSelector"": [
+                            {
+                                ""ShouldSelect"": ""C#|Vars.status == \""Success\"""",
+                                ""Child"": ""OverwriteAction""
+                            }
+                        ]
+                    },
+                    ""OverwriteAction"": {
+                        ""Type"": ""Action"",
+                        ""Actions"": {
+                            ""OverwriteAction_TardigradeAction"": {
+                                ""Action"": ""TardigradeAction"",
+                                ""OutputBindings"": {
+                                    ""status"": ""Status""
+                                }
+                            }
+                        },
+                        ""ChildSelector"": [
+                            {
+                                ""ShouldSelect"": ""C#|Vars.status == \""Success\"""",
+                                ""Child"": ""Done""
+                            }
+                        ]
+                    },
+                    ""Done"": {
+                        ""Type"": ""Leaf""
+                    }
+                }
+            }";
+
+        public const string OutputBindings_UsedInInput = @"
+            {
+                ""Tree"": {
+                    ""Root"": {
+                        ""Type"": ""Action"",
+                        ""Actions"": {
+                            ""Root_CollectDiagnosticsAction"": {
+                                ""Action"": ""CollectDiagnosticsAction"",
+                                ""Input"": {
+                                    ""Command"": ""FirstCommand""
+                                },
+                                ""OutputBindings"": {
+                                    ""firstOutput"": ""Output""
+                                }
+                            }
+                        },
+                        ""ChildSelector"": [
+                            {
+                                ""Child"": ""UseVarInInput""
+                            }
+                        ]
+                    },
+                    ""UseVarInInput"": {
+                        ""Type"": ""Action"",
+                        ""Actions"": {
+                            ""UseVarInInput_CollectDiagnosticsAction"": {
+                                ""Action"": ""CollectDiagnosticsAction"",
+                                ""Input"": {
+                                    ""Command"": ""C#|\""Process_\"" + Vars.firstOutput.ToString()""
+                                },
+                                ""OutputBindings"": {
+                                    ""secondOutput"": ""Output""
+                                }
+                            }
+                        },
+                        ""ChildSelector"": [
+                            {
+                                ""ShouldSelect"": ""C#|Vars.secondOutput != null"",
+                                ""Child"": ""Done""
+                            }
+                        ]
+                    },
+                    ""Done"": {
+                        ""Type"": ""Leaf""
+                    }
+                }
+            }";
+
+        public const string OutputBindings_GetVarAccessor = @"
+            {
+                ""Tree"": {
+                    ""Root"": {
+                        ""Type"": ""Action"",
+                        ""Actions"": {
+                            ""Root_CollectDiagnosticsAction"": {
+                                ""Action"": ""CollectDiagnosticsAction"",
+                                ""Input"": {
+                                    ""Command"": ""RunDiagnostics""
+                                },
+                                ""OutputBindings"": {
+                                    ""myStatus"": ""Status""
+                                }
+                            }
+                        },
+                        ""ChildSelector"": [
+                            {
+                                ""ShouldSelect"": ""C#|(string)Session.GetVar(\""myStatus\"") == \""Success\"""",
+                                ""Child"": ""Done""
+                            }
+                        ]
+                    },
+                    ""Done"": {
+                        ""Type"": ""Leaf""
+                    }
+                }
+            }";
+
+        #endregion OutputBindings Schemas
     }
 }

--- a/Forge.TreeWalker.UnitTests/test/TreeWalkerUnitTests.cs
+++ b/Forge.TreeWalker.UnitTests/test/TreeWalkerUnitTests.cs
@@ -1346,5 +1346,172 @@ namespace Microsoft.Forge.TreeWalker.UnitTests
 
             return new TreeWalkerSession(subroutineParameters);
         }
+
+        #region OutputBindings
+
+        [TestMethod]
+        public void TestOutputBindings_BasicStatus_Success()
+        {
+            // Test - OutputBindings can bind the Status property and use it in ShouldSelect.
+            this.TestInitialize(jsonSchema: ForgeSchemaHelper.OutputBindings_BasicStatus);
+            string actualStatus = this.session.WalkTree("Root").GetAwaiter().GetResult();
+            Assert.AreEqual("RanToCompletion", actualStatus, "Expected WalkTree to run to completion with OutputBindings.");
+
+            // Verify the tree walked to the Success leaf.
+            string currentNode = this.session.GetCurrentTreeNode().GetAwaiter().GetResult();
+            Assert.AreEqual("Success", currentNode, "Expected to reach Success node via OutputBindings ShouldSelect.");
+        }
+
+        [TestMethod]
+        public void TestOutputBindings_OutputProperty_Success()
+        {
+            // Test - OutputBindings can bind the entire Output object.
+            this.TestInitialize(jsonSchema: ForgeSchemaHelper.OutputBindings_OutputProperty);
+            string actualStatus = this.session.WalkTree("Root").GetAwaiter().GetResult();
+            Assert.AreEqual("RanToCompletion", actualStatus, "Expected WalkTree to run to completion.");
+
+            string currentNode = this.session.GetCurrentTreeNode().GetAwaiter().GetResult();
+            Assert.AreEqual("HasOutput", currentNode, "Expected to reach HasOutput node since Output is not null.");
+        }
+
+        [TestMethod]
+        public void TestOutputBindings_CrossNode_Persists()
+        {
+            // Test - Variables bound in one node are accessible in a later node's ShouldSelect.
+            this.TestInitialize(jsonSchema: ForgeSchemaHelper.OutputBindings_CrossNode);
+            string actualStatus = this.session.WalkTree("Root").GetAwaiter().GetResult();
+            Assert.AreEqual("RanToCompletion", actualStatus, "Expected WalkTree to run to completion.");
+
+            string currentNode = this.session.GetCurrentTreeNode().GetAwaiter().GetResult();
+            Assert.AreEqual("BothSuccess", currentNode, "Expected to reach BothSuccess node since both firstStatus and secondStatus are Success.");
+        }
+
+        [TestMethod]
+        public void TestOutputBindings_VarOverwrite_Success()
+        {
+            // Test - A later action can overwrite a variable bound by an earlier action.
+            this.TestInitialize(jsonSchema: ForgeSchemaHelper.OutputBindings_VarOverwrite);
+            string actualStatus = this.session.WalkTree("Root").GetAwaiter().GetResult();
+            Assert.AreEqual("RanToCompletion", actualStatus, "Expected WalkTree to run to completion.");
+
+            string currentNode = this.session.GetCurrentTreeNode().GetAwaiter().GetResult();
+            Assert.AreEqual("Done", currentNode, "Expected to reach Done node since overwritten status is still Success.");
+        }
+
+        [TestMethod]
+        public void TestOutputBindings_UsedInInput_Success()
+        {
+            // Test - Vars can be referenced in Input expressions of subsequent actions.
+            this.TestInitialize(jsonSchema: ForgeSchemaHelper.OutputBindings_UsedInInput);
+            string actualStatus = this.session.WalkTree("Root").GetAwaiter().GetResult();
+            Assert.AreEqual("RanToCompletion", actualStatus, "Expected WalkTree to run to completion.");
+
+            string currentNode = this.session.GetCurrentTreeNode().GetAwaiter().GetResult();
+            Assert.AreEqual("Done", currentNode, "Expected to reach Done node.");
+        }
+
+        [TestMethod]
+        public void TestOutputBindings_GetVarAccessor_Success()
+        {
+            // Test - Session.GetVar() can be used in ShouldSelect expressions as an alternative to Vars.
+            this.TestInitialize(jsonSchema: ForgeSchemaHelper.OutputBindings_GetVarAccessor);
+            string actualStatus = this.session.WalkTree("Root").GetAwaiter().GetResult();
+            Assert.AreEqual("RanToCompletion", actualStatus, "Expected WalkTree to run to completion.");
+
+            string currentNode = this.session.GetCurrentTreeNode().GetAwaiter().GetResult();
+            Assert.AreEqual("Done", currentNode, "Expected to reach Done node via Session.GetVar accessor.");
+        }
+
+        [TestMethod]
+        public void TestOutputBindings_GetVar_ReturnsNull_ForUnboundVariable()
+        {
+            // Test - GetVar returns null for a variable that hasn't been bound.
+            this.TestFromFileInitialize(filePath: TardigradeSchemaPath);
+            object result = this.session.GetVar("nonExistentVar");
+            Assert.IsNull(result, "Expected GetVar to return null for an unbound variable.");
+        }
+
+        [TestMethod]
+        public void TestOutputBindings_ResolveDotPath_Status()
+        {
+            // Test - ResolveDotPath resolves "Status" property from an ActionResponse.
+            ActionResponse response = new ActionResponse { Status = "Success", StatusCode = 200, Output = "TestOutput" };
+            object result = TreeWalkerSession.ResolveDotPath(response, "Status");
+            Assert.AreEqual("Success", result);
+        }
+
+        [TestMethod]
+        public void TestOutputBindings_ResolveDotPath_StatusCode()
+        {
+            // Test - ResolveDotPath resolves "StatusCode" property from an ActionResponse.
+            ActionResponse response = new ActionResponse { Status = "Success", StatusCode = 42, Output = null };
+            object result = TreeWalkerSession.ResolveDotPath(response, "StatusCode");
+            Assert.AreEqual(42, result);
+        }
+
+        [TestMethod]
+        public void TestOutputBindings_ResolveDotPath_Output()
+        {
+            // Test - ResolveDotPath resolves "Output" as the whole object.
+            var outputObj = new { Name = "test", Value = 42 };
+            ActionResponse response = new ActionResponse { Status = "Success", Output = outputObj };
+            object result = TreeWalkerSession.ResolveDotPath(response, "Output");
+            Assert.AreEqual(outputObj, result);
+        }
+
+        [TestMethod]
+        public void TestOutputBindings_ResolveDotPath_NullRoot_Throws()
+        {
+            // Test - ResolveDotPath throws ArgumentNullException on null root.
+            Assert.ThrowsException<ArgumentNullException>(() =>
+            {
+                TreeWalkerSession.ResolveDotPath(null, "Status");
+            });
+        }
+
+        [TestMethod]
+        public void TestOutputBindings_ResolveDotPath_EmptyPath_Throws()
+        {
+            // Test - ResolveDotPath throws ArgumentException on empty path.
+            ActionResponse response = new ActionResponse { Status = "Success" };
+            Assert.ThrowsException<ArgumentException>(() =>
+            {
+                TreeWalkerSession.ResolveDotPath(response, "");
+            });
+        }
+
+        [TestMethod]
+        public void TestOutputBindings_ResolveDotPath_InvalidProperty_Throws()
+        {
+            // Test - ResolveDotPath throws OutputBindingException for a property that doesn't exist.
+            ActionResponse response = new ActionResponse { Status = "Success" };
+            Assert.ThrowsException<OutputBindingException>(() =>
+            {
+                TreeWalkerSession.ResolveDotPath(response, "NonExistentProperty");
+            });
+        }
+
+        [TestMethod]
+        public void TestOutputBindings_WalkTree_FromFile_Success()
+        {
+            // Test - Walk tree using the OutputBindingsSchema.json file.
+            this.TestFromFileInitialize(filePath: "test\\ExampleSchemas\\OutputBindingsSchema.json");
+            string actualStatus = this.session.WalkTree("Root").GetAwaiter().GetResult();
+            Assert.AreEqual("RanToCompletion", actualStatus, "Expected WalkTree to run to completion with OutputBindings schema file.");
+
+            string currentNode = this.session.GetCurrentTreeNode().GetAwaiter().GetResult();
+            Assert.AreEqual("AnalysisComplete", currentNode, "Expected to reach AnalysisComplete node.");
+        }
+
+        [TestMethod]
+        public void TestOutputBindings_NoBindings_WorksNormally()
+        {
+            // Test - Actions without OutputBindings still work (backward compatibility).
+            this.TestFromFileInitialize(filePath: TardigradeSchemaPath);
+            string actualStatus = this.session.WalkTree("Root").GetAwaiter().GetResult();
+            Assert.AreEqual("RanToCompletion", actualStatus, "Expected WalkTree to run to completion without OutputBindings.");
+        }
+
+        #endregion OutputBindings
     }
 }

--- a/Forge.TreeWalker/contracts/ForgeSchemaValidationRules.json
+++ b/Forge.TreeWalker/contracts/ForgeSchemaValidationRules.json
@@ -219,6 +219,14 @@
                 },
                 "ContinuationOnRetryExhaustion": {
                     "type": "boolean"
+                },
+                "OutputBindings": {
+                    "type": "object",
+                    "patternProperties": {
+                        ".*?": {
+                            "type": "string"
+                        }
+                    }
                 }
             },
             "additionalProperties": false,

--- a/Forge.TreeWalker/contracts/ForgeTree.cs
+++ b/Forge.TreeWalker/contracts/ForgeTree.cs
@@ -163,6 +163,15 @@ namespace Microsoft.Forge.DataContracts
         /// </summary>
         [DataMember]
         public bool ContinuationOnRetryExhaustion { get; set; }
+
+        /// <summary>
+        /// Optional output bindings that extract values from the ActionResponse and bind them to named variables.
+        /// The key is the variable name accessible via Vars in Roslyn expressions (e.g., "Vars.myVar").
+        /// The value is a dot-path into the ActionResponse (e.g., "Status", "Output.PropertyName", "Output.Items[0].Name").
+        /// Bound variables persist for the entire session and are available in subsequent ShouldSelect and Input expressions.
+        /// </summary>
+        [DataMember]
+        public Dictionary<string, string> OutputBindings { get; set; }
     }
 
     /// <summary>

--- a/Forge.TreeWalker/src/ExpressionExecutor.cs
+++ b/Forge.TreeWalker/src/ExpressionExecutor.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Forge.TreeWalker
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Collections.Immutable;
+    using System.Dynamic;
     using System.Reflection;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
@@ -163,7 +164,8 @@ namespace Microsoft.Forge.TreeWalker
                 Assembly mscorlib = typeof(object).Assembly;
                 Assembly systemCore = typeof(System.Linq.Enumerable).Assembly;
                 Assembly cSharpAssembly = typeof(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo).Assembly;
-                scriptOptions = scriptOptions.AddReferences(mscorlib, systemCore, cSharpAssembly);
+                Assembly systemDynamic = typeof(System.Dynamic.ExpandoObject).Assembly;
+                scriptOptions = scriptOptions.AddReferences(mscorlib, systemCore, cSharpAssembly, systemDynamic);
 
                 // Add required namespaces.
                 scriptOptions = scriptOptions.AddImports(
@@ -209,6 +211,16 @@ namespace Microsoft.Forge.TreeWalker
         }
 
         /// <summary>
+        /// Gets the Vars ExpandoObject from the CodeGenInputParams.
+        /// This allows the TreeWalkerSession to populate output binding variables.
+        /// </summary>
+        /// <returns>The Vars ExpandoObject as an IDictionary.</returns>
+        public IDictionary<string, object> GetVars()
+        {
+            return (IDictionary<string, object>)this.parameters.Vars;
+        }
+
+        /// <summary>
         /// This class defines the global parameter that will be passed into the Roslyn expression evaluator.
         /// 
         /// TODO: When Creating a Roslyn Script, the entire Assembly that the passed in GlobalsType resides in gets loaded.
@@ -232,6 +244,13 @@ namespace Microsoft.Forge.TreeWalker
             /// For Subroutines, this is evaluated from the SubroutineInput on the schema.
             /// </summary>
             public dynamic TreeInput { get; set; }
+
+            /// <summary>
+            /// The dynamic Vars object that holds output binding variables.
+            /// Variables are populated from TreeAction OutputBindings after actions complete.
+            /// Schema expressions can reference bound variables as Vars.variableName.
+            /// </summary>
+            public dynamic Vars { get; set; } = new ExpandoObject();
         }
 
         /// <summary>

--- a/Forge.TreeWalker/src/ForgeExceptions.cs
+++ b/Forge.TreeWalker/src/ForgeExceptions.cs
@@ -90,4 +90,29 @@ namespace Microsoft.Forge.TreeWalker.ForgeExceptions
         {
         }
     }
+
+    /// <summary>
+    /// Exception thrown when an output binding fails to resolve.
+    /// </summary>
+    public class OutputBindingException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OutputBindingException"/> class.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        public OutputBindingException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OutputBindingException"/> class.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="inner">The inner exception.</param>
+        public OutputBindingException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+    }
 }

--- a/Forge.TreeWalker/src/ITreeSession.cs
+++ b/Forge.TreeWalker/src/ITreeSession.cs
@@ -46,5 +46,13 @@ namespace Microsoft.Forge.TreeWalker
         /// Gets the string context if the actions in the current tree node were skipped, or null if actions were not skipped.
         /// </summary>
         string GetCurrentNodeSkipActionContext();
+
+        /// <summary>
+        /// Gets the value of a bound output variable by name.
+        /// Variables are populated from TreeAction OutputBindings after actions complete.
+        /// </summary>
+        /// <param name="name">The variable name as defined in OutputBindings.</param>
+        /// <returns>The bound value if it exists, otherwise null.</returns>
+        object GetVar(string name);
     }
 }

--- a/Forge.TreeWalker/src/TreeNodeContext.cs
+++ b/Forge.TreeWalker/src/TreeNodeContext.cs
@@ -10,6 +10,7 @@
 namespace Microsoft.Forge.TreeWalker
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading;
 
     /// <summary>
@@ -61,6 +62,13 @@ namespace Microsoft.Forge.TreeWalker
         public string CurrentNodeSkipActionContext { get; set; }
 
         /// <summary>
+        /// The output binding variables resolved from TreeAction OutputBindings after actions complete.
+        /// Available in AfterVisitNode callbacks. Null in BeforeVisitNode (bindings haven't run yet).
+        /// Callbacks can use this to read bound output values and store them in external tables or state.
+        /// </summary>
+        public IDictionary<string, object> OutputVars { get; private set; }
+
+        /// <summary>
         /// Instantiates an TreeNodeContext object.
         /// </summary>
         /// <param name="sessionId">The Id of this tree walking session.</param>
@@ -73,6 +81,9 @@ namespace Microsoft.Forge.TreeWalker
         /// <param name="currentNodeSkipActionContext">
         /// The string context if the actions in the current tree node should be skipped, or null if actions should not be skipped.
         /// </param>
+        /// <param name="outputVars">
+        /// The output binding variables resolved from TreeAction OutputBindings. Null in BeforeVisitNode.
+        /// </param>
         public TreeNodeContext(
             Guid sessionId,
             string treeNodeKey,
@@ -81,7 +92,8 @@ namespace Microsoft.Forge.TreeWalker
             CancellationToken token,
             string treeName,
             Guid rootSessionId,
-            string currentNodeSkipActionContext)
+            string currentNodeSkipActionContext,
+            IDictionary<string, object> outputVars = null)
         {
             if (sessionId == null) throw new ArgumentNullException("sessionId");
             if (string.IsNullOrWhiteSpace(treeNodeKey)) throw new ArgumentNullException("treeNodeKey");
@@ -97,6 +109,7 @@ namespace Microsoft.Forge.TreeWalker
             this.TreeName = treeName;
             this.RootSessionId = rootSessionId;
             this.CurrentNodeSkipActionContext = currentNodeSkipActionContext;
+            this.OutputVars = outputVars;
         }
     }
 }

--- a/Forge.TreeWalker/src/TreeWalkerSession.cs
+++ b/Forge.TreeWalker/src/TreeWalkerSession.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Forge.TreeWalker
     using System.Collections;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Dynamic;
+    using System.Linq;
     using System.Reflection;
     using System.Text.RegularExpressions;
     using System.Threading;
@@ -58,6 +60,12 @@ namespace Microsoft.Forge.TreeWalker
         /// Key: <SessionId>_TI
         /// </summary>
         public static string TreeInputSuffix = "TI";
+
+        /// <summary>
+        /// The OutputVars suffix appended to the end of the key in forgeState that maps to the output binding variables.
+        /// Key: <SessionId>_OV
+        /// </summary>
+        public static string OutputVarsSuffix = "OV";
 
         /// <summary>
         /// The PreviousActionResponse suffix appended to the end of the key in forgeState that maps to a previously persisted ActionResponse.
@@ -167,6 +175,9 @@ namespace Microsoft.Forge.TreeWalker
             this.Parameters.TreeInput = this.GetOrCommitTreeInput(parameters.TreeInput).GetAwaiter().GetResult();
 
             this.expressionExecutor = new ExpressionExecutor(this as ITreeSession, parameters.UserContext, parameters.Dependencies, parameters.ScriptCache, this.Parameters.TreeInput);
+
+            // Rehydrate output binding variables from ForgeState if previously persisted.
+            this.RehydrateOutputVars();
 
             if (parameters.RootSessionId == Guid.Empty)
             {
@@ -283,6 +294,18 @@ namespace Microsoft.Forge.TreeWalker
         }
 
         /// <summary>
+        /// Gets the value of a bound output variable by name.
+        /// Variables are populated from TreeAction OutputBindings after actions complete.
+        /// </summary>
+        /// <param name="name">The variable name as defined in OutputBindings.</param>
+        /// <returns>The bound value if it exists, otherwise null.</returns>
+        public object GetVar(string name)
+        {
+            IDictionary<string, object> vars = this.expressionExecutor.GetVars();
+            return vars.TryGetValue(name, out object value) ? value : null;
+        }
+
+        /// <summary>
         /// Signals the WalkTree and VisitNode cancellation token sources to cancel.
         /// </summary>
         public void CancelWalkTree()
@@ -368,7 +391,8 @@ namespace Microsoft.Forge.TreeWalker
                                 this.walkTreeCts.Token,
                                 this.Parameters.TreeName,
                                 this.Parameters.RootSessionId,
-                                this.currentNodeSkipActionContext
+                                this.currentNodeSkipActionContext,
+                                this.GetOutputVarsSnapshot()
                             );
 
                             await this.Parameters.CallbacksV2.AfterVisitNode(treeNodeContext).ConfigureAwait(false);
@@ -703,6 +727,10 @@ namespace Microsoft.Forge.TreeWalker
                 // Exceptions are thrown here if the action hit a timeout, was cancelled, or failed.
                 await completedTask;
             }
+
+            // After all actions on this node have completed, resolve output bindings sequentially.
+            // This is done after all parallel actions complete to avoid thread-safety issues with the shared Vars ExpandoObject.
+            await this.ResolveAllOutputBindingsForNode(treeNode, treeNodeKey).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1202,6 +1230,317 @@ namespace Microsoft.Forge.TreeWalker
             {
                 return null;
             }
+        }
+
+        /// <summary>
+        /// After all actions on a node have completed, resolves output bindings for each action that has them.
+        /// This is called sequentially after all parallel actions complete, ensuring thread-safe access to the shared Vars ExpandoObject.
+        /// Also handles continuation responses (timeout/retry-exhaustion) that committed synthetic ActionResponses.
+        /// </summary>
+        /// <param name="treeNode">The TreeNode whose actions have completed.</param>
+        /// <param name="treeNodeKey">The TreeNode's key.</param>
+        private async Task ResolveAllOutputBindingsForNode(TreeNode treeNode, string treeNodeKey)
+        {
+            if (treeNode.Actions == null)
+            {
+                return;
+            }
+
+            bool hasBindings = false;
+
+            foreach (KeyValuePair<string, TreeAction> kvp in treeNode.Actions)
+            {
+                string treeActionKey = kvp.Key;
+                TreeAction treeAction = kvp.Value;
+
+                if (treeAction.OutputBindings == null || treeAction.OutputBindings.Count == 0)
+                {
+                    continue;
+                }
+
+                ActionResponse actionResponse = await this.GetOutputAsync(treeActionKey).ConfigureAwait(false);
+                if (actionResponse != null)
+                {
+                    this.ResolveOutputBindings(treeActionKey, treeAction, actionResponse);
+                    hasBindings = true;
+                }
+            }
+
+            if (hasBindings)
+            {
+                await this.CommitOutputVars().ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Processes output bindings for a TreeAction by resolving dot-paths against the ActionResponse
+        /// and storing the results as named variables on the Vars ExpandoObject.
+        /// </summary>
+        /// <param name="treeActionKey">The TreeAction's key of the action that was executed.</param>
+        /// <param name="treeAction">The TreeAction with optional OutputBindings.</param>
+        /// <param name="actionResponse">The ActionResponse returned from the action.</param>
+        internal void ResolveOutputBindings(string treeActionKey, TreeAction treeAction, ActionResponse actionResponse)
+        {
+            if (treeAction.OutputBindings == null || treeAction.OutputBindings.Count == 0)
+            {
+                return;
+            }
+
+            IDictionary<string, object> vars = this.expressionExecutor.GetVars();
+
+            foreach (KeyValuePair<string, string> binding in treeAction.OutputBindings)
+            {
+                string varName = binding.Key;
+                string dotPath = binding.Value;
+
+                try
+                {
+                    object resolvedValue = ResolveDotPath(actionResponse, dotPath);
+                    vars[varName] = resolvedValue;
+                }
+                catch (Exception e)
+                {
+                    throw new OutputBindingException(
+                        string.Format(
+                            "Failed to resolve output binding. TreeActionKey: {0}, Variable: {1}, DotPath: {2}.",
+                            treeActionKey,
+                            varName,
+                            dotPath),
+                        e);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Resolves a dot-path expression against a root object.
+        /// Supports property access, array indexing (e.g., "Items[0]"), and nested traversal.
+        /// Handles both JObject/JToken (from JSON deserialization) and CLR objects (via reflection).
+        /// </summary>
+        /// <param name="root">The root object to resolve against.</param>
+        /// <param name="path">The dot-path expression (e.g., "Output.Metrics.SuccessRate", "Output.Items[0].Name").</param>
+        /// <returns>The resolved value with its original type.</returns>
+        internal static object ResolveDotPath(object root, string path)
+        {
+            if (root == null)
+            {
+                throw new ArgumentNullException("root", "Cannot resolve dot-path on a null object.");
+            }
+
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new ArgumentException("Dot-path cannot be null or empty.", "path");
+            }
+
+            object current = root;
+
+            // Split on '.' but respect bracket segments (e.g., "Items[0].Name" => ["Items[0]", "Name"])
+            string[] segments = path.Split('.');
+
+            foreach (string segment in segments)
+            {
+                if (current == null)
+                {
+                    throw new OutputBindingException(
+                        string.Format("Null value encountered while resolving dot-path '{0}' at segment '{1}'.", path, segment));
+                }
+
+                // Check if segment contains array indexing (e.g., "Items[0]")
+                string propertyName = segment;
+                int arrayIndex = -1;
+
+                int bracketStart = segment.IndexOf('[');
+                if (bracketStart >= 0)
+                {
+                    int bracketEnd = segment.IndexOf(']', bracketStart);
+                    if (bracketEnd < 0)
+                    {
+                        throw new OutputBindingException(
+                            string.Format("Malformed array index in dot-path '{0}' at segment '{1}'. Missing closing bracket.", path, segment));
+                    }
+
+                    propertyName = segment.Substring(0, bracketStart);
+                    string indexStr = segment.Substring(bracketStart + 1, bracketEnd - bracketStart - 1);
+                    if (!int.TryParse(indexStr, out arrayIndex))
+                    {
+                        throw new OutputBindingException(
+                            string.Format("Invalid array index '{0}' in dot-path '{1}' at segment '{2}'.", indexStr, path, segment));
+                    }
+
+                    if (arrayIndex < 0)
+                    {
+                        throw new OutputBindingException(
+                            string.Format("Negative array index '{0}' in dot-path '{1}' at segment '{2}'.", arrayIndex, path, segment));
+                    }
+
+                    // Reject trailing text after closing bracket (e.g., "Items[0]foo")
+                    if (bracketEnd < segment.Length - 1)
+                    {
+                        throw new OutputBindingException(
+                            string.Format("Unexpected text after array index in dot-path '{0}' at segment '{1}'.", path, segment));
+                    }
+                }
+
+                // Resolve the property if property name is not empty
+                if (!string.IsNullOrEmpty(propertyName))
+                {
+                    current = ResolveProperty(current, propertyName, path, segment);
+                }
+
+                // Apply array indexing if present
+                if (arrayIndex >= 0)
+                {
+                    current = ResolveArrayIndex(current, arrayIndex, path, segment);
+                }
+            }
+
+            // Unwrap JValue to its underlying .NET type
+            if (current is JValue jValue)
+            {
+                return jValue.Value;
+            }
+
+            return current;
+        }
+
+        /// <summary>
+        /// Resolves a property name on the given object. Handles JObject, JToken, and CLR objects.
+        /// </summary>
+        private static object ResolveProperty(object obj, string propertyName, string fullPath, string segment)
+        {
+            if (obj is JObject jObj)
+            {
+                JToken token = jObj[propertyName];
+                if (token == null)
+                {
+                    throw new OutputBindingException(
+                        string.Format("Property '{0}' not found on JObject while resolving dot-path '{1}'.", propertyName, fullPath));
+                }
+
+                return token;
+            }
+
+            // Try reflection for CLR objects
+            Type objType = obj.GetType();
+            PropertyInfo prop = objType.GetProperty(propertyName);
+            if (prop != null)
+            {
+                return prop.GetValue(obj);
+            }
+
+            // Try as IDictionary<string, object> (e.g., ExpandoObject)
+            if (obj is IDictionary<string, object> dict)
+            {
+                if (dict.TryGetValue(propertyName, out object value))
+                {
+                    return value;
+                }
+            }
+
+            throw new OutputBindingException(
+                string.Format("Property '{0}' not found on type '{1}' while resolving dot-path '{2}'.", propertyName, objType.Name, fullPath));
+        }
+
+        /// <summary>
+        /// Resolves an array index on the given object. Handles JArray, IList, and arrays.
+        /// </summary>
+        private static object ResolveArrayIndex(object obj, int index, string fullPath, string segment)
+        {
+            if (obj is JArray jArray)
+            {
+                if (index < 0 || index >= jArray.Count)
+                {
+                    throw new OutputBindingException(
+                        string.Format("Array index {0} is out of bounds (length: {1}) in dot-path '{2}' at segment '{3}'.", index, jArray.Count, fullPath, segment));
+                }
+
+                return jArray[index];
+            }
+
+            if (obj is IList list)
+            {
+                if (index < 0 || index >= list.Count)
+                {
+                    throw new OutputBindingException(
+                        string.Format("Array index {0} is out of bounds (length: {1}) in dot-path '{2}' at segment '{3}'.", index, list.Count, fullPath, segment));
+                }
+
+                return list[index];
+            }
+
+            throw new OutputBindingException(
+                string.Format("Cannot apply array index to type '{0}' in dot-path '{1}' at segment '{2}'.", obj.GetType().Name, fullPath, segment));
+        }
+
+        /// <summary>
+        /// Persists the current Vars to ForgeState.
+        /// </summary>
+        private async Task CommitOutputVars()
+        {
+            IDictionary<string, object> vars = this.expressionExecutor.GetVars();
+            Dictionary<string, object> snapshot = new Dictionary<string, object>(vars);
+            await this.Parameters.ForgeState.Set<object>(OutputVarsSuffix, snapshot).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Rehydrates Vars from ForgeState if previously persisted.
+        /// </summary>
+        private void RehydrateOutputVars()
+        {
+            try
+            {
+                object persisted = this.Parameters.ForgeState.GetValue<object>(OutputVarsSuffix).GetAwaiter().GetResult();
+                if (persisted != null)
+                {
+                    IDictionary<string, object> vars = this.expressionExecutor.GetVars();
+
+                    if (persisted is JObject jObj)
+                    {
+                        foreach (KeyValuePair<string, JToken> kvp in jObj)
+                        {
+                            // Unwrap JValue to CLR types so Roslyn expressions work correctly
+                            // (e.g., Vars.status == "Success" compares string to string, not JValue to string).
+                            vars[kvp.Key] = UnwrapJToken(kvp.Value);
+                        }
+                    }
+                    else if (persisted is IDictionary<string, object> dict)
+                    {
+                        foreach (KeyValuePair<string, object> kvp in dict)
+                        {
+                            vars[kvp.Key] = kvp.Value is JToken jt ? UnwrapJToken(jt) : kvp.Value;
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // No persisted vars; this is fine.
+            }
+        }
+
+        /// <summary>
+        /// Unwraps a JToken to its underlying CLR type.
+        /// JValue becomes string/int/bool/etc, JObject/JArray stay as-is for dynamic access.
+        /// </summary>
+        private static object UnwrapJToken(JToken token)
+        {
+            if (token is JValue jValue)
+            {
+                return jValue.Value;
+            }
+
+            // JObject and JArray support dynamic property access and indexing,
+            // so they work well as-is in Roslyn expressions.
+            return token;
+        }
+
+        /// <summary>
+        /// Gets a snapshot of the current output binding variables.
+        /// </summary>
+        /// <returns>A dictionary of variable names to their bound values, or null if no variables are bound.</returns>
+        internal IDictionary<string, object> GetOutputVarsSnapshot()
+        {
+            IDictionary<string, object> vars = this.expressionExecutor.GetVars();
+            return vars.Count > 0 ? new Dictionary<string, object>(vars) : null;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Adds a new `OutputBindings` property to `TreeAction` that allows schema authors to declaratively bind ActionResponse properties to named variables. These variables are accessible via `Vars.<name>` in Roslyn expressions (`ShouldSelect`, action inputs, etc.), significantly reducing schema verbosity and improving readability.

## Motivation

Today, `ShouldSelect` expressions in Forge schemas must use verbose Roslyn expressions to access action output properties:

**Before (current):**
```json
{
  "ShouldSelect": "C#|Session.GetLastActionResponse().Status == \"Success\" && ((Newtonsoft.Json.Linq.JObject)Session.GetLastActionResponse().Output)[\"Metrics\"][\"Utilization\"].Value<double>() > 80.0"
}
```

This is hard to read, error-prone, and requires deep knowledge of the Roslyn expression API. With `OutputBindings`, the same logic becomes:

**After (with OutputBindings):**
```json
{
  "Actions": {
    "CollectMetrics_Action": {
      "Action": "CollectMetricsAction",
      "OutputBindings": {
        "diagStatus": "Status",
        "utilization": "Output.Metrics.Utilization"
      }
    }
  },
  "ChildSelector": [
    {
      "ShouldSelect": "C#|Vars.diagStatus == \"Success\" && (double)Vars.utilization > 80.0",
      "Child": "HighUtilizationNode"
    }
  ]
}
```

## How It Works

### Schema Definition

`OutputBindings` is an optional `Dictionary<string, string>` on `TreeAction`:
- **Key**: Variable name (accessible as `Vars.<name>` in expressions)
- **Value**: Dot-path into the `ActionResponse` (e.g., `Status`, `Output.Metrics.Score`, `Output.Items[0].Name`)

### Supported Dot-Path Expressions

| Path | Resolves To |
|------|------------|
| `Status` | `ActionResponse.Status` (string) |
| `StatusCode` | `ActionResponse.StatusCode` (int) |
| `Output` | `ActionResponse.Output` (object) |
| `Output.PropertyName` | Nested property on Output |
| `Output.Items[0]` | Array element access |
| `Output.Items[0].Name` | Nested property on array element |

### Expression Access

Bound variables are available on the `Vars` dynamic object in all Roslyn expressions:

```
// Boolean routing
C#|Vars.diagStatus == "Success"

// Numeric comparison
C#|(double)Vars.utilization > 80.0

// Combine multiple variables from different actions
C#|Vars.isolationResult == "Completed" && Vars.verifyStatus == "Verified"

// Use in action inputs
C#|Vars.ticketId

// Access via Session.GetVar() in code
C#|Session.GetVar("diagStatus")?.ToString() == "Success"
```

### Variable Scope & Lifetime

- Variables are **session-scoped**  they persist across nodes within the same tree walk
- Later bindings with the same name **overwrite** earlier ones
- Variables survive **rehydration** (persisted to ForgeState)
- Variables are available in `AfterVisitNode` callbacks via `TreeNodeContext.OutputVars`

## Complete Schema Example

```json
{
  "Tree": {
    "Root": {
      "Type": "Action",
      "Actions": {
        "CollectDiagnostics_Action": {
          "Action": "CollectDiagnosticsAction",
          "Input": "C#|\"RunDiagnostics\"",
          "OutputBindings": {
            "diagStatus": "Status",
            "diagOutput": "Output"
          }
        }
      },
      "ChildSelector": [
        {
          "ShouldSelect": "C#|Vars.diagStatus == \"Success\"",
          "Child": "SuccessNode"
        },
        {
          "ShouldSelect": "C#|Vars.diagStatus != \"Success\"",
          "Child": "FailureNode"
        }
      ]
    },
    "SuccessNode": {
      "Type": "Action",
      "Actions": {
        "ApplyFix_Action": {
          "Action": "ApplyFixAction",
          "Input": "C#|Vars.diagOutput",
          "OutputBindings": {
            "fixResult": "Status"
          }
        }
      },
      "ChildSelector": [
        {
          "ShouldSelect": "C#|Vars.fixResult == \"Success\"",
          "Child": "VerifyNode"
        }
      ]
    },
    "FailureNode": { "Type": "Leaf" },
    "VerifyNode": { "Type": "Leaf" }
  }
}
```

## Implementation Details

### Files Changed

| File | Change |
|------|--------|
| `ForgeTree.cs` | Added `OutputBindings` property to `TreeAction` |
| `ExpressionExecutor.cs` | Added `Vars` (ExpandoObject) to `CodeGenInputParams`, `System.Dynamic` assembly ref |
| `TreeWalkerSession.cs` | Core logic: `ResolveAllOutputBindingsForNode`, `ResolveOutputBindings`, `ResolveDotPath`, `CommitOutputVars`, `RehydrateOutputVars`, `GetVar` |
| `ITreeSession.cs` | Added `GetVar(string name)` method |
| `TreeNodeContext.cs` | Added `OutputVars` dictionary for callback access |
| `ForgeExceptions.cs` | Added `OutputBindingException` |
| `ForgeSchemaValidationRules.json` | Added `OutputBindings` to ActionDefinition schema |
| Unit tests | 14 test methods + 6 inline schemas + 1 file-based example schema |

### Design Decisions

1. **Thread safety**: Bindings are resolved *after* all parallel actions on a node complete (not per-action), ensuring safe access to the shared `Vars` ExpandoObject.
2. **Continuation responses**: Bindings work with timeout and retry-exhaustion synthetic responses  `ResolveAllOutputBindingsForNode` reads the committed response regardless of how it was produced.
3. **JValue unwrapping**: Rehydrated values are unwrapped from `JValue` to CLR types so string comparisons (`Vars.status == "Success"`) work correctly.
4. **Dot-path validation**: Negative array indexes and malformed bracket syntax (e.g., `Items[0]foo`) are rejected with descriptive `OutputBindingException` messages.

### Breaking Change Note

`ITreeSession.GetVar(string name)` is a new method on the public interface. Existing implementations will need to add this method (can return `null`). This was chosen over an extension method because .NET Standard 2.0 doesn't support default interface methods.

## Testing

- 14 unit tests covering: basic status binding, output property access, cross-node variable persistence, variable overwriting, variable use in action inputs, `GetVar` accessor, schema validation
- 6 inline test schemas + 1 file-based example schema